### PR TITLE
add routes macro

### DIFF
--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -39,9 +39,6 @@ fn main() {
     }
     pretty_env_logger::init();
 
-    // These are some `Filter`s that several of the endpoints share,
-    // so we'll define them here and reuse them below...
-
     // Turn our "state", our db, into a Filter so we can combine it
     // easily with others...
     let db = Arc::new(Mutex::new(Vec::<Todo>::new()));
@@ -52,16 +49,12 @@ fn main() {
         ["todos"] => |p| {
             get {
                 // `GET /todos`
-                // Combined with `index`, this means nothing comes after "todos".
-                // So, for example: `GET /todos`, but not `GET /todos/32`.
-                p.and(warp::path::index())
-                 .and(db.clone())
+                p.and(db.clone())
                  .map(list_todos)
             };
             post {
                 // `POST /todos`
-                p.and(warp::path::index())
-                 .and(warp::body::json())
+                p.and(warp::body::json())
                  .and(db.clone())
                  .and_then(create_todo)
             };
@@ -69,15 +62,13 @@ fn main() {
         ["todos" / u64] => |p| {
             put {
                 // `PUT /todos/:id`
-                p.and(warp::path::index())
-                 .and(warp::body::json())
+                p.and(warp::body::json())
                  .and(db.clone())
                  .and_then(update_todo)
             };
             delete {
                 // `DELETE /todos/:id`
-                p.and(warp::path::index())
-                 .and(db.clone())
+                p.and(db.clone())
                  .and_then(delete_todo)
             };
         }

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -47,27 +47,27 @@ fn main() {
     // Combine our endpoints, since we want requests to match any of them:
     let api = routes! {
         ["todos"] => |p| {
+            // `GET /todos`
             get {
-                // `GET /todos`
                 p.and(db.clone())
                  .map(list_todos)
             };
+            // `POST /todos`
             post {
-                // `POST /todos`
                 p.and(warp::body::json())
                  .and(db.clone())
                  .and_then(create_todo)
             };
         }
         ["todos" / u64] => |p| {
+            // `PUT /todos/:id`
             put {
-                // `PUT /todos/:id`
                 p.and(warp::body::json())
                  .and(db.clone())
                  .and_then(update_todo)
             };
+             // `DELETE /todos/:id`
             delete {
-                // `DELETE /todos/:id`
                 p.and(db.clone())
                  .and_then(delete_todo)
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,14 +75,18 @@
 //! [Filter]: trait.Filter.html
 
 extern crate base64;
-#[macro_use] extern crate bitflags;
+#[macro_use]
+extern crate bitflags;
 extern crate bytes;
-#[macro_use] extern crate futures;
+#[macro_use]
+extern crate futures;
 #[doc(hidden)]
 pub extern crate http;
 extern crate hyper;
-#[macro_use] extern crate log as logcrate;
-#[macro_use] extern crate scoped_tls;
+#[macro_use]
+extern crate log as logcrate;
+#[macro_use]
+extern crate scoped_tls;
 extern crate serde;
 extern crate serde_json;
 extern crate serde_urlencoded;
@@ -94,6 +98,7 @@ mod error;
 mod filter;
 pub mod filters;
 mod generic;
+mod macros;
 mod never;
 pub mod reject;
 pub mod reply;
@@ -102,7 +107,7 @@ mod server;
 pub mod test;
 
 pub use self::error::Error;
-pub use self::filter::{Filter};
+pub use self::filter::Filter;
 // This otherwise shows a big dump of re-exports in the doc homepage,
 // with zero context, so just hide it from the docs. Doc examples
 // on each can show that a convenient import exists.
@@ -121,7 +126,7 @@ pub use self::filters::{
     log,
     // log() function
     log::log,
-    method::{get, method, post, put, delete},
+    method::{delete, get, method, post, put},
     path,
     // the index() function
     path::index,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,22 @@
+#[macro_export]
+macro_rules! routes {
+    (@method $p:ident $m:ident $h:expr) => {
+        $crate::$m($h)
+    };
+    (@path [$($path:tt)*] => |$p:ident| { $fm:ident $fh:expr; $($m:ident $h:expr;)*}) => {
+        {
+            let $p = path!($($path)*);
+            routes!(@method $p $fm $fh)
+            $(
+            .or(routes!(@method $p $m $h))
+            )*
+        }
+    };
+    ([$($path:tt)*] => |$p:ident| { $fm:ident $fh:expr; $($m:ident $h:expr;)*}
+     $([$($tpath:tt)*] => |$tp:ident| { $tfm:ident $tfh:expr; $($tm:ident $th:expr;)*})*) => {
+        routes!(@path [$($path)*] => |$p| { $fm $fh; $($m $h;)* })
+        $(
+        .or(routes!(@path [$($tpath)*] => |$tp| { $tfm $tfh; $($tm $th;)* }))
+        )*
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,6 +3,15 @@ macro_rules! routes {
     (@method $p:ident $m:ident $h:expr) => {
         $crate::$m($h)
     };
+    (@path ["/"] => |$p:ident| { $fm:ident $fh:expr; $($m:ident $h:expr;)*}) => {
+        {
+            let $p = $crate::path::index();
+            routes!(@method $p $fm $fh)
+            $(
+            .or(routes!(@method $p $m $h))
+            )*
+        }
+    };
     (@path [$($path:tt)*] => |$p:ident| { $fm:ident $fh:expr; $($m:ident $h:expr;)*}) => {
         {
             let $p = path!($($path)*).and($crate::path::index());

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,7 +5,7 @@ macro_rules! routes {
     };
     (@path [$($path:tt)*] => |$p:ident| { $fm:ident $fh:expr; $($m:ident $h:expr;)*}) => {
         {
-            let $p = path!($($path)*);
+            let $p = path!($($path)*).and($crate::path::index());
             routes!(@method $p $fm $fh)
             $(
             .or(routes!(@method $p $m $h))


### PR DESCRIPTION
It would be great to have some utilities help to compose endpoint filters. This PR added routes macro to do so, thought?

### Steps
- Defined endpoint URL
- Supported method e.g. POST, GET, PUT, DELETE
- Handling logic

### Example
```rust
let api = routes! {
    ["todos"] => |p| {
        // `GET /todos`
        get {
            p.and(db.clone()).map(list_todos)
        };
        // `POST /todos`
        post {
            p.and(warp::body::json()).and(db.clone()).and_then(create_todo)
        };
    }
    ["todos" / u64] => |p| {
        // `PUT /todos/:id`
        put {
            p.and(warp::body::json()).and(db.clone()).and_then(update_todo)
        };
        // `DELETE /todos/:id`
        delete {
            p.and(db.clone()).and_then(delete_todo)
        };
    }
};
// View access logs by setting `RUST_LOG=todos`.
let routes = api.with(warp::log("todos"));
```