### PR TITLE
dir: urldecode route before creating path from it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ sha-1 = "0.7"
 tokio = "0.1.7"
 # tls is enabled by default, we don't want that yet
 tungstenite = { default-features = false, version = "0.6" }
+urlencoding = "1.0.0"
 
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ extern crate serde_urlencoded;
 extern crate sha1;
 extern crate tokio;
 extern crate tungstenite;
+extern crate urlencoding;
 
 mod error;
 mod filter;

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -40,6 +40,24 @@ fn dir() {
 }
 
 #[test]
+fn dir_encoded() {
+    let _ = pretty_env_logger::try_init();
+
+    let file = warp::fs::dir("examples");
+
+    let req = warp::test::request()
+        .path("/todos%2ers");
+    let res = req.reply(&file);
+
+    assert_eq!(res.status(), 200);
+
+    let contents = fs::read("examples/todos.rs").expect("fs::read");
+    assert_eq!(res.headers()["content-length"], contents.len().to_string());
+
+    assert_eq!(res.body(), &*contents);
+}
+
+#[test]
 fn dir_not_found() {
     let _ = pretty_env_logger::try_init();
 
@@ -66,3 +84,16 @@ fn dir_bad_path() {
     assert_eq!(res.body(), "");
 }
 
+#[test]
+fn dir_bad_encoded_path() {
+    let _ = pretty_env_logger::try_init();
+
+    let file = warp::fs::dir("examples");
+
+    let req = warp::test::request()
+        .path("/%2E%2e/README.md");
+    let res = req.reply(&file);
+
+    assert_eq!(res.status(), 400);
+    assert_eq!(res.body(), "");
+}


### PR DESCRIPTION
I think hyper already rules out the `Err` branch by validating the whole path earlier.