### PR TITLE
Add method::v2 wrapping filters

### DIFF
--- a/src/filters/method.rs
+++ b/src/filters/method.rs
@@ -137,3 +137,144 @@ where
     })
 }
 
+pub mod v2 {
+    //! HTTP Method Filters
+    //!
+    //! These filters deal with the HTTP Method part of a request. They match
+    //! the request `Method`, and if not matched, will reject the request with a
+    //! `405 Method Not Allowed`.
+    //!
+    //! These "filters" behave a little differently than the rest. Instead of
+    //! being used directly on requests, these filters "wrap" other filters.
+    //!
+    //!
+    //! ## Wrapping a `Filter` (`with`)
+    //!
+    //! ```
+    //! use warp::Filter;
+    //! use warp::filters::method::v2 as methodv2;
+    //!
+    //! let route = warp::any()
+    //!     .map(warp::reply);
+    //!
+    //! // This filter rejects any non-GET requests before they get to the
+    //! // wrapped `route`.
+    //! let get_only = route
+    //!     .with(methodv2::get());
+    //! ```
+    //!
+    //! Wrapping allows adding in conditional logic *before* the request enters
+    //! the inner filter. In the example, it rejects non-GET requests before
+    //! they get to the wrapped `route` filter.
+    use futures::{future::FutureResult, IntoFuture};
+    use http::Method;
+
+    use filter::{And, Filter, FilterBase, MapErr, WrapSealed};
+    use reject::{CombineRejection, Rejection};
+    use reply::Reply;
+
+    /// Wrap a `Filter` to require that the request method to be `GET`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use warp::Filter;
+    /// use warp::filters::method::v2 as methodv2;
+    ///
+    /// let route = warp::any().map(warp::reply);
+    /// let get_only = route.with(methodv2::get());
+    /// ```
+    pub fn get() -> WithMethod {
+        WithMethod(&Method::GET)
+    }
+
+    /// Wrap a `Filter` to require that the request method to be `POST`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use warp::Filter;
+    /// use warp::filters::method::v2 as methodv2;
+    ///
+    /// let route = warp::any().map(warp::reply);
+    /// let post_only = route.with(methodv2::post());
+    /// ```
+    pub fn post() -> WithMethod {
+        WithMethod(&Method::POST)
+    }
+
+    /// Wrap a `Filter` to require that the request method to be `PUT`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use warp::Filter;
+    /// use warp::filters::method::v2 as methodv2;
+    ///
+    /// let route = warp::any().map(warp::reply);
+    /// let put_only = route.with(methodv2::put());
+    /// ```
+    pub fn put() -> WithMethod {
+        WithMethod(&Method::PUT)
+    }
+
+    /// Wrap a `Filter` to require that the request method to be `DELETE`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use warp::Filter;
+    /// use warp::filters::method::v2 as methodv2;
+    ///
+    /// let route = warp::any().map(warp::reply);
+    /// let delete_only = route.with(methodv2::delete());
+    /// ```
+    pub fn delete() -> WithMethod {
+        WithMethod(&Method::DELETE)
+    }
+
+    /// Wrap a `Filter` to require a specific HTTP method.
+    #[derive(Debug, Clone, Copy)]
+    pub struct WithMethod(&'static Method);
+
+    impl<F> WrapSealed<F> for WithMethod
+    where
+        F: Filter + Clone + Send,
+        F::Extract: Reply,
+        F::Error: CombineRejection<Rejection>,
+        <<F as FilterBase>::Error as CombineRejection<Rejection>>::Rejection:
+            CombineRejection<Rejection>,
+    {
+        type Wrapped = And<
+            MethodIs,
+            MapErr<F, fn(F::Error) -> <F::Error as CombineRejection<Rejection>>::Rejection>,
+        >;
+
+        fn wrap(&self, filter: F) -> Self::Wrapped {
+            MethodIs(self.0)
+                .and(filter.map_err(|err| err.cancel(::reject::method_not_allowed())))
+        }
+    }
+
+    /// A `Filter` that requires the request have a specific method.
+    #[derive(Debug, Clone, Copy)]
+    pub struct MethodIs(&'static Method);
+
+    impl FilterBase for MethodIs where {
+        type Extract = ();
+        type Error = Rejection;
+        type Future = FutureResult<(), Rejection>;
+
+        fn filter(&self) -> Self::Future {
+            let method = self.0;
+            ::route::with(|route| {
+                trace!("method::{:?}?: {:?}", method, route.method());
+                if route.method() == method {
+                    Ok(())
+                } else {
+                    Err(::reject::method_not_allowed())
+                }
+            }).into_future()
+        }
+    }
+}

--- a/tests/method.rs
+++ b/tests/method.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 extern crate warp;
 
-use warp::Filter;
+use warp::{filters::method::v2 as methodv2, Filter};
 
 #[test]
 fn method() {
@@ -21,9 +21,47 @@ fn method() {
 }
 
 #[test]
+fn methodv2() {
+    let get = warp::any().map(warp::reply)
+        .with(methodv2::get());
+
+    let req = warp::test::request();
+    assert!(req.matches(&get));
+
+    let req = warp::test::request()
+        .method("POST");
+    assert!(!req.matches(&get));
+
+    let req = warp::test::request()
+        .method("POST");
+    let resp = req.reply(&get);
+    assert_eq!(resp.status(), 405);
+}
+
+#[test]
 fn cancels_method_not_allowed() {
     let get = warp::get(warp::path("hello").map(warp::reply));
     let post = warp::post(warp::path("bye").map(warp::reply));
+
+    let routes = get.or(post);
+
+
+    let req = warp::test::request()
+        .method("GET")
+        .path("/bye");
+
+    let resp = req.reply(&routes);
+    // A GET was allowed, but the path was wrong, so it should return
+    // a 404, not a 405.
+    assert_eq!(resp.status(), 404);
+}
+
+#[test]
+fn v2_cancels_method_not_allowed() {
+    let get = warp::path("hello").map(warp::reply)
+        .with(methodv2::get());
+    let post = warp::path("bye").map(warp::reply)
+        .with(methodv2::post());
 
     let routes = get.or(post);
 


### PR DESCRIPTION
This commit adds `Wrap`-based method filters, mirroring the existing
methods.

refs #14