### PR TITLE
feature: filter for raw query strings

### DIFF
--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -23,7 +23,7 @@ pub fn query<T: DeserializeOwned + Send>() -> impl Filter<Extract=One<T>, Error=
 }
 
 /// Creates a `Filter` that returns the raw query string as type String.
-pub fn raw_query() -> impl Filter<Extract=One<String>, Error=Rejection> + Copy {
+pub fn raw() -> impl Filter<Extract=One<String>, Error=Rejection> + Copy {
     filter_fn_one(|route| {
         route
             .query()

--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -21,3 +21,16 @@ pub fn query<T: DeserializeOwned + Send>() -> impl Filter<Extract=One<T>, Error=
             .unwrap_or_else(|| Err(reject::bad_request()))
     })
 }
+
+/// Creates a `Filter` that returns the raw query string as type String.
+pub fn raw_query() -> impl Filter<Extract=One<String>, Error=Rejection> + Copy {
+    filter_fn_one(|route| {
+        route
+            .query()
+            .map(|q| {
+                q.to_owned()
+            })
+            .map(Ok)
+            .unwrap_or_else(|| Err(reject::bad_request()))
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,8 @@ pub use self::filters::{
     query,
     // query() function
     query::query,
+    // raw_query() function
+    query::raw_query,
     ws,
     // ws() function
     ws::ws,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,8 +130,6 @@ pub use self::filters::{
     query,
     // query() function
     query::query,
-    // raw_query() function
-    query::raw_query,
     ws,
     // ws() function
     ws::ws,

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -17,7 +17,7 @@ fn query() {
 
 #[test]
 fn raw_query() {
-    let as_raw = warp::raw_query();
+    let as_raw = warp::query::raw();
 
     let req = warp::test::request()
         .path("/?foo=bar&baz=quux");

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -14,3 +14,14 @@ fn query() {
     assert_eq!(extracted["foo"], "bar");
     assert_eq!(extracted["baz"], "quux");
 }
+
+#[test]
+fn raw_query() {
+    let as_raw = warp::raw_query();
+
+    let req = warp::test::request()
+        .path("/?foo=bar&baz=quux");
+
+    let extracted = req.filter(&as_raw).unwrap();
+    assert_eq!(extracted, "foo=bar&baz=quux".to_owned());
+}


### PR DESCRIPTION
A new filter `raw_query()` creates a `Filter` that returns the raw query
string as type String.

- new fn `filters::query::raw_query()`
- expose fn publicly as `warp::raw_query()` in lib.rs
- simple test in `tests/query/rs`