### PR TITLE
boxed: Use Into in place of From in error bound

### DIFF
--- a/src/filter/boxed.rs
+++ b/src/filter/boxed.rs
@@ -26,11 +26,11 @@ impl<T: Tuple + Send> BoxedFilter<T> {
         F: Filter<
             Extract=T,
         > + Send + Sync + 'static,
-        Rejection: From<F::Error>,
+        F::Error : Into<Rejection>,
     {
         BoxedFilter {
             filter: Arc::new(BoxingFilter {
-                filter: filter.map_err(Rejection::from),
+                filter: filter.map_err(Into::into),
             }),
         }
     }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -362,7 +362,7 @@ pub trait Filter: FilterBase {
     where
         Self: Sized + Send + Sync + 'static,
         Self::Extract: Send,
-        Rejection: From<Self::Error>,
+        Self::Error: Into<Rejection>,
     {
         BoxedFilter::new(self)
     }


### PR DESCRIPTION
This will make it possible for users to use `Filter::boxed` with their
custom filters and error types once the traits are unsealed.