### PR TITLE
add `hyper::Service` and `hyper::NewService` trait implementations for `WarpService`

### DIFF
--- a/src/filter/service.rs
+++ b/src/filter/service.rs
@@ -4,7 +4,7 @@ use ::{Filter, Request};
 use ::reject::Reject;
 use ::reply::{Reply};
 use ::route::{self, Route};
-use ::server::{IntoWarpService, WarpService};
+use ::service::{IntoWarpService, WarpService};
 
 #[derive(Copy, Clone, Debug)]
 pub struct FilteredService<F> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ pub mod reply;
 mod route;
 mod server;
 pub mod test;
+mod service;
 
 pub use self::error::Error;
 pub use self::filter::{Filter};
@@ -152,6 +153,7 @@ pub use self::reject::{reject, Rejection};
 #[doc(hidden)]
 pub use self::reply::{reply, Reply};
 pub use self::server::{serve, Server};
+pub use self::service::new_service;
 pub use hyper::rt::spawn;
 
 #[doc(hidden)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,14 +1,11 @@
 use std::net::SocketAddr;
-use std::sync::Arc;
 
-use futures::{Async, Future, Poll};
+use futures::Future;
 use hyper::{rt, Server as HyperServer};
-use hyper::service::{service_fn};
 
-use ::never::Never;
 use ::reject::Reject;
-use ::reply::{ReplySealed, Reply};
-use ::Request;
+use ::reply::Reply;
+use ::service::{IntoWarpService, WarpService, new_service};
 
 /// Create a `Server` with the provided service.
 pub fn serve<S>(service: S) -> Server<S>
@@ -55,18 +52,10 @@ where
     /// Returns the bound address and a `Future` that can be executed on
     /// any runtime.
     pub fn bind_ephemeral(self, addr: impl Into<SocketAddr> + 'static) -> (SocketAddr, impl Future<Item=(), Error=()> + 'static) {
-        let inner = Arc::new(self.service.into_warp_service());
-        let service = move || {
-            let inner = inner.clone();
-            service_fn(move |req| {
-                ReplyFuture {
-                    inner: inner.call(req)
-                }
-            })
-        };
+        let factory = new_service(self.service);
         let srv = HyperServer::bind(&addr.into())
             .http1_pipeline_flush(self.pipeline)
-            .serve(service);
+            .serve(factory);
         let addr = srv.local_addr();
         (addr, srv.map_err(|e| error!("server error: {}", e)))
     }
@@ -78,43 +67,6 @@ where
     pub fn unstable_pipeline(mut self) -> Self {
         self.pipeline = true;
         self
-    }
-}
-
-pub trait IntoWarpService {
-    type Service: WarpService + Send + Sync + 'static;
-    fn into_warp_service(self) -> Self::Service;
-}
-
-pub trait WarpService {
-    type Reply: Future + Send;
-    fn call(&self, req: Request) -> Self::Reply;
-}
-
-
-// Optimizes better than using Future::then, since it doesn't
-// have to return an IntoFuture.
-#[derive(Debug)]
-struct ReplyFuture<F> {
-    inner: F,
-}
-
-impl<F> Future for ReplyFuture<F>
-where
-    F: Future,
-    F::Item: Reply,
-    F::Error: Reject,
-{
-    type Item = ::reply::Response;
-    type Error = Never;
-
-    #[inline]
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.inner.poll() {
-            Ok(Async::Ready(ok)) => Ok(Async::Ready(ok.into_response())),
-            Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(err) => Ok(Async::Ready(err.into_response())),
-        }
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+use hyper::{service as hyper_service, Body};
+use futures::{Future, Poll, Async, future::FutureResult, future};
+
+use ::Request;
+use ::never::Never;
+use ::reply::{Reply, ReplySealed};
+use ::reject::Reject;
+
+#[derive(Debug)]
+pub struct HyperService<T> {
+    inner: Arc<T>
+}
+
+impl<T,R> hyper_service::Service for HyperService<T>
+where
+    T: WarpService<Reply = R>,
+    R: Future + Send,
+    R::Item: Reply + Send,
+    R::Error: Reject + Send
+{
+    type ReqBody = Body;
+    type ResBody = Body;
+    type Error = Never;
+    type Future = ReplyFuture<T::Reply>;
+
+    #[inline]
+    fn call(&mut self, req: Request) -> Self::Future {
+        let inner = self.inner.clone();
+        ReplyFuture {
+           inner: inner.call(req)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct HyperNewService<T> {
+    inner: Arc<T>
+}
+
+/// Converts given `service` instance into `HyperNewService` factory.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate hyper;
+/// # extern crate warp;
+/// use warp::{Future, Filter, new_service};
+/// use hyper::Server;
+///
+/// fn main() {
+///   let addr = ([127, 0, 0, 1], 3000).into();
+///   let endpoint = warp::any().map(|| "hello");
+///   let factory = new_service(endpoint);
+///   let server = Server::bind(&addr)
+///     .serve(factory)
+///     .map_err(|err| panic!("server error: {}", err));
+///   # drop(server)
+/// }
+/// ```
+///
+pub fn new_service<T>(service: T) -> HyperNewService<T::Service>
+where T: IntoWarpService {
+    HyperNewService { inner: Arc::new(service.into_warp_service()) }
+}
+
+impl<T, R> hyper_service::NewService for HyperNewService<T>
+where
+    T: WarpService<Reply = R>,
+    R: Future + Send,
+    R::Item: Reply + Send,
+    R::Error: Reject + Send
+{
+    type ReqBody = Body;
+    type ResBody = Body;
+    type Error = Never;
+    type Service = HyperService<T>;
+    type Future = FutureResult<Self::Service, Self::InitError>;
+    type InitError = Never;
+
+    #[inline]
+    fn new_service(&self) -> Self::Future {
+        let instance = HyperService { inner: self.inner.clone() };
+        future::ok(instance)
+    }
+}
+
+// Optimizes better than using Future::then, since it doesn't
+// have to return an IntoFuture.
+#[derive(Debug)]
+pub struct ReplyFuture<F> {
+    inner: F,
+}
+
+impl<F> Future for ReplyFuture<F>
+where
+    F: Future,
+    F::Item: Reply,
+    F::Error: Reject,
+{
+    type Item = ::reply::Response;
+    type Error = Never;
+
+    #[inline]
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.inner.poll() {
+            Ok(Async::Ready(ok)) => Ok(Async::Ready(ok.into_response())),
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Err(err) => Ok(Async::Ready(err.into_response())),
+        }
+    }
+}
+
+pub trait IntoWarpService {
+    type Service: WarpService + Send + Sync + 'static;
+    fn into_warp_service(self) -> Self::Service;
+}
+
+pub trait WarpService {
+    type Reply: Future + Send;
+    fn call(&self, req: ::Request) -> Self::Reply;
+}


### PR DESCRIPTION
As I see, a creation of `hyper::NewService` hardcoded inside `Server::bind_ephemeral` method,
so I've created a separate module `service`, that provides `hyper::NewService` trait implementation for wap services. It would be useful if warp uses together with customized tokio runtime or hyper stacks. 