### PR TITLE
Expand documentation on returning filters from functions

### DIFF
--- a/examples/returning.rs
+++ b/examples/returning.rs
@@ -1,0 +1,21 @@
+extern crate warp;
+
+use warp::{Filter, filters::BoxedFilter, Rejection, Reply};
+
+// Option 1: BoxedFilter
+pub fn assets_filter() -> BoxedFilter<(impl Reply,)> {
+    warp::path("assets")
+        .and(warp::fs::dir("./assets"))
+        .boxed()
+}
+
+// Option 2: impl Filter
+pub fn index_filter() -> impl Filter<Extract = (&'static str,), Error = Rejection> {
+    warp::index().map(|| "Index page")
+}
+
+pub fn main() {
+    let routes = index_filter().or(assets_filter());
+    warp::serve(routes)
+        .run(([127, 0, 0, 1], 3030));
+}

--- a/src/filter/boxed.rs
+++ b/src/filter/boxed.rs
@@ -12,6 +12,19 @@ use super::{FilterBase, Filter, Tuple};
 /// to ease returning `Filter`s from other functions.
 ///
 /// To create one, call `Filter::boxed` on any filter.
+/// 
+/// # Examples
+///
+/// ```
+/// use warp::{Filter, filters::BoxedFilter, Reply};
+/// 
+/// pub fn assets_filter() -> BoxedFilter<(impl Reply,)> {
+///     warp::path("assets")
+///         .and(warp::fs::dir("./assets"))
+///         .boxed()
+/// }
+/// ```
+///
 pub struct BoxedFilter<T: Tuple> {
     filter: Arc<Filter<
         Extract = T,


### PR DESCRIPTION
This PR adds an example that shows the two main ways to return a filter from a function. It also adds a short example to the `BoxedFilter` docs in case someone stumbles across that before they find `Filter::boxed()`. I don't know whether the redundancy is worth it, but I added the example before I realized that the existing examples were there (since they're not in the docs.rs version yet), so they're in there, but I can also remove them.