### PR TITLE
Treat no query string as empty query string

### DIFF
--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -13,6 +13,7 @@ pub fn query<T: DeserializeOwned + Send>() -> impl Filter<Extract=One<T>, Error=
     filter_fn_one(|route| {
         route
             .query()
+            .or(Some(""))
             .and_then(|q| {
                 serde_urlencoded::from_str(q)
                     .ok()

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,5 +1,7 @@
 #![deny(warnings)]
 extern crate warp;
+#[macro_use]
+extern crate serde_derive;
 
 use std::collections::HashMap;
 
@@ -13,6 +15,84 @@ fn query() {
     let extracted = req.filter(&as_map).unwrap();
     assert_eq!(extracted["foo"], "bar");
     assert_eq!(extracted["baz"], "quux");
+}
+
+#[test]
+fn query_struct() {
+    let as_struct = warp::query::<MyArgs>();
+
+    let req = warp::test::request()
+        .path("/?foo=bar&baz=quux");
+
+    let extracted = req.filter(&as_struct).unwrap();
+    assert_eq!(extracted, MyArgs { foo: Some("bar".into()), baz: Some("quux".into()) });
+}
+
+#[test]
+fn empty_query_struct() {
+    let as_struct = warp::query::<MyArgs>();
+
+    let req = warp::test::request()
+        .path("/?");
+
+    let extracted = req.filter(&as_struct).unwrap();
+    assert_eq!(extracted, MyArgs { foo: None, baz: None });
+}
+
+#[test]
+fn missing_query_struct() {
+    let as_struct = warp::query::<MyArgs>();
+
+    let req = warp::test::request()
+        .path("/");
+
+    let extracted = req.filter(&as_struct).unwrap();
+    assert_eq!(extracted, MyArgs { foo: None, baz: None });
+}
+
+#[derive(Deserialize, Debug, Eq, PartialEq)]
+struct MyArgs {
+    foo: Option<String>,
+    baz: Option<String>,
+}
+
+#[test]
+fn required_query_struct() {
+    let as_struct = warp::query::<MyRequiredArgs>();
+
+    let req = warp::test::request()
+        .path("/?foo=bar&baz=quux");
+
+    let extracted = req.filter(&as_struct).unwrap();
+    assert_eq!(extracted, MyRequiredArgs { foo: "bar".into(), baz: "quux".into() });
+}
+
+#[test]
+fn missing_required_query_struct_partial() {
+    let as_struct = warp::query::<MyRequiredArgs>();
+
+    let req = warp::test::request()
+        .path("/?foo=something");
+
+    let extracted = req.filter(&as_struct);
+    assert!(extracted.is_err())
+}
+
+#[test]
+fn missing_required_query_struct_no_query() {
+    let as_struct = warp::query::<MyRequiredArgs>();
+
+    let req = warp::test::request()
+        .path("/");
+
+    let extracted = req.filter(&as_struct);
+    assert!(extracted.is_err())
+}
+
+#[derive(Deserialize, Debug, Eq, PartialEq)]
+struct MyRequiredArgs {
+    foo: String,
+    baz: String,
 }
 
 #[test]


### PR DESCRIPTION
If there is optional query parameters to a handler, treat an URL with no question mark as equal to an URL that ends in a question mark.  Technically, the URL ending in a question mark has an empty query string while the URL without a question mark has no query string, but in practice, it should not make any difference and the question mark is rarely present.

If there are required query parameters, I don't think this makes any difference either, as extracting them from an empty string will fail fast (and the fail should behave the same with or without that question mark anyway).

This fixes #86 in the place where it is easy to fix.  Also added a bunch of tests for missing query strings (and query string missing required pieces).