### PR TITLE
Add last-modified header to file and dir filters (#45)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio-io = "0.1"
 # tls is enabled by default, we don't want that yet
 tungstenite = { default-features = false, version = "0.6" }
 urlencoding = "1.0.0"
+httpdate = "0.3.2"
 
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ extern crate tokio;
 extern crate tokio_io;
 extern crate tungstenite;
 extern crate urlencoding;
+extern crate httpdate;
 
 mod error;
 mod filter;


### PR DESCRIPTION
This pull request sets the last-modified header when serving responses from the file system.

This implementation uses [httpdate](https://github.com/pyfisch/httpdate) to format the date.
It appears that Hyper uses the deprecated [time](https://github.com/rust-lang-deprecated/time) crate; which is also an option.