### PR TITLE
Fix typo in `with_status` documentation

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -203,7 +203,7 @@ fn _assert_object_safe() {
     fn _assert(_: &Reply) {}
 }
 
-/// Wrap an `impl Reply` to add a header when rendering.
+/// Wrap an `impl Reply` to change its `StatusCode`.
 ///
 /// # Example
 ///


### PR DESCRIPTION
Previously referred to headers; should refer to status codes.