### PR TITLE
rework Rejection system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["web-programming::http-server"]
 keywords = ["warp", "server", "http", "hyper"]
 
 [dependencies]
-bitflags = "1"
 bytes = "0.4.8"
 futures = "0.1"
 #headers = { path = "../headers" }

--- a/examples/futures.rs
+++ b/examples/futures.rs
@@ -2,29 +2,42 @@
 extern crate tokio;
 extern crate warp;
 
+use std::str::FromStr;
 use std::time::{Duration, Instant};
 use tokio::timer::Delay;
 use warp::{Filter, Future};
 
+/// A newtype to enforce our maximum allowed seconds.
+struct Seconds(u64);
+
+impl FromStr for Seconds {
+    type Err = ();
+    fn from_str(src: &str) -> Result<Self, Self::Err> {
+        src
+            .parse::<u64>()
+            .map_err(|_| ())
+            .and_then(|num| {
+                if num <= 5 {
+                    Ok(Seconds(num))
+                } else {
+                    Err(())
+                }
+            })
+    }
+}
+
 fn main() {
     // Match `/:u32`...
     let routes = warp::path::param()
-        // Reject any that have too-high a number
-        .and_then(|seconds: u64| {
-            if seconds <= 5 {
-                Ok(seconds)
-            } else {
-                Err(warp::reject())
-            }
-        })
-        // and_then create a `Future` that will simply wait 3 seconds...
-        .and_then(|seconds| {
+        // and_then create a `Future` that will simply wait N seconds...
+        .and_then(|Seconds(seconds)| {
             Delay::new(Instant::now() + Duration::from_secs(seconds))
                 // return the number of seconds again...
                 .map(move |()| seconds)
                 // An error from `Delay` means a big problem with the server...
                 .map_err(|timer_err| {
-                    warp::reject::server_error().with(timer_err)
+                    eprintln!("timer error: {}", timer_err);
+                    warp::reject::custom(timer_err)
                 })
         })
         .map(|seconds| format!("I waited {} seconds!", seconds));

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -130,7 +130,7 @@ fn create_todo(create: Todo, db: Db) -> Result<impl warp::Reply, warp::Rejection
         if todo.id == create.id {
             debug!("    -> id already exists: {}", create.id);
             // Todo with id already exists, return `400 BadRequest`.
-            return Err(warp::reject::bad_request());
+            return Ok(StatusCode::BAD_REQUEST);
         }
     }
 

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -226,7 +226,7 @@ pub trait Filter: FilterBase {
     ///     if id != 0 {
     ///         Ok(format!("Hello #{}", id))
     ///     } else {
-    ///         Err(warp::reject())
+    ///         Err(warp::reject::not_found())
     ///     }
     /// });
     /// ```

--- a/src/filters/cookie.rs
+++ b/src/filters/cookie.rs
@@ -16,7 +16,7 @@ pub fn cookie(name: &'static str) -> impl Filter<Extract=One<String>, Error=Reje
             cookie
                 .get(name)
                 .map(String::from)
-                .ok_or_else(|| ::reject::bad_request())
+                .ok_or_else(|| ::reject::known(MissingCookie(name)))
         })
 }
 
@@ -55,3 +55,20 @@ where
     })
 }
 
+
+// ===== Rejections =====
+
+#[derive(Debug)]
+pub(crate) struct MissingCookie(&'static str);
+
+impl ::std::fmt::Display for MissingCookie {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "Missing request cookie '{}'", self.0)
+    }
+}
+
+impl ::std::error::Error for MissingCookie {
+    fn description(&self) -> &str {
+        "Missing request cookie"
+    }
+}

--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -240,7 +240,10 @@ where
         }
         T::from_str(seg)
             .map(one)
-            .map_err(|err| reject::not_found().with(err.into()))
+            .map_err(|err| {
+                #[allow(deprecated)]
+                reject::not_found().with(err.into())
+            })
     })
 }
 

--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -19,7 +19,7 @@ pub fn query<T: DeserializeOwned + Send>() -> impl Filter<Extract=One<T>, Error=
                     .ok()
             })
             .map(Ok)
-            .unwrap_or_else(|| Err(reject::bad_request()))
+            .unwrap_or_else(|| Err(reject::known(InvalidQuery)))
     })
 }
 
@@ -32,6 +32,22 @@ pub fn raw() -> impl Filter<Extract=One<String>, Error=Rejection> + Copy {
                 q.to_owned()
             })
             .map(Ok)
-            .unwrap_or_else(|| Err(reject::bad_request()))
+            .unwrap_or_else(|| Err(reject::known(InvalidQuery)))
     })
 }
+
+#[derive(Debug)]
+pub(crate) struct InvalidQuery;
+
+impl ::std::fmt::Display for InvalidQuery {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        f.write_str("Invalid query string")
+    }
+}
+
+impl ::std::error::Error for InvalidQuery {
+    fn description(&self) -> &str {
+        "Invalid query string"
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,6 @@
 //!
 //! [Filter]: trait.Filter.html
 
-#[macro_use] extern crate bitflags;
 extern crate bytes;
 #[macro_use] extern crate futures;
 extern crate headers_ext as headers;
@@ -153,6 +152,7 @@ pub use self::filters::{
 #[doc(hidden)]
 pub use self::redirect::{redirect};
 #[doc(hidden)]
+#[allow(deprecated)]
 pub use self::reject::{reject, Rejection};
 #[doc(hidden)]
 pub use self::reply::{reply, Reply};

--- a/src/server.rs
+++ b/src/server.rs
@@ -209,7 +209,10 @@ where
         match self.inner.poll() {
             Ok(Async::Ready(ok)) => Ok(Async::Ready(ok.into_response())),
             Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(err) => Ok(Async::Ready(err.into_response())),
+            Err(err) => {
+                debug!("rejected: {:?}", err);
+                Ok(Async::Ready(err.into_response()))
+            }
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -210,7 +210,10 @@ impl RequestBuilder {
         let route = Route::new(self.req);
         let mut fut = route::set(&route, move || f.filter())
             .map(|rep| rep.into_response())
-            .or_else(|rej| Ok(rej.into_response()))
+            .or_else(|rej| {
+                debug!("rejected: {:?}", rej);
+                Ok(rej.into_response())
+            })
             .and_then(|res| {
                 let (parts, body) = res.into_parts();
                 body

--- a/tests/cookie.rs
+++ b/tests/cookie.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+extern crate pretty_env_logger;
 extern crate warp;
 
 #[test]
@@ -41,4 +42,18 @@ fn optional() {
     let req = warp::test::request()
         .header("cookie", "foobar=quux");
     assert!(req.matches(&foo));
+}
+
+#[test]
+fn missing() {
+    let _ = pretty_env_logger::try_init();
+
+    let cookie = warp::cookie("foo");
+
+    let res = warp::test::request()
+        .header("cookie", "not=here")
+        .reply(&cookie);
+
+    assert_eq!(res.status(), 400);
+    assert_eq!(res.body(), "Missing request cookie 'foo'");
 }

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -84,8 +84,7 @@ fn dir_bad_path() {
         .path("/../README.md");
     let res = req.reply(&file);
 
-    assert_eq!(res.status(), 400);
-    assert_eq!(String::from_utf8_lossy(res.body()), "dir: rejecting segment");
+    assert_eq!(res.status(), 404);
 }
 
 #[test]
@@ -98,8 +97,7 @@ fn dir_bad_encoded_path() {
         .path("/%2E%2e/README.md");
     let res = req.reply(&file);
 
-    assert_eq!(res.status(), 400);
-    assert_eq!(String::from_utf8_lossy(res.body()), "dir: rejecting segment");
+    assert_eq!(res.status(), 404);
 }
 
 #[test]

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -2,6 +2,8 @@
 extern crate pretty_env_logger;
 extern crate warp;
 
+use warp::Filter;
+
 #[test]
 fn exact() {
     let _ = pretty_env_logger::try_init();
@@ -20,4 +22,26 @@ fn exact() {
     let req = warp::test::request()
         .header("host", "hyper.rs");
     assert!(!req.matches(&host), "header value different");
+}
+
+#[test]
+fn exact_rejections() {
+    let _ = pretty_env_logger::try_init();
+
+    let host = warp::header::exact("host", "localhost")
+        .map(warp::reply);
+
+    let res = warp::test::request()
+        .header("host", "nope")
+        .reply(&host);
+
+    assert_eq!(res.status(), 400);
+    assert_eq!(res.body(), "Invalid request header 'host'");
+
+    let res = warp::test::request()
+        .header("not-even-a-host", "localhost")
+        .reply(&host);
+
+    assert_eq!(res.status(), 400);
+    assert_eq!(res.body(), "Missing request header 'host'");
 }

--- a/tests/method.rs
+++ b/tests/method.rs
@@ -1,10 +1,12 @@
 #![deny(warnings)]
+extern crate pretty_env_logger;
 extern crate warp;
 
 use warp::Filter;
 
 #[test]
 fn method() {
+    let _ = pretty_env_logger::try_init();
     let get = warp::get2().map(warp::reply);
 
     let req = warp::test::request();
@@ -22,6 +24,7 @@ fn method() {
 
 #[test]
 fn method_not_allowed_trumps_not_found() {
+    let _ = pretty_env_logger::try_init();
     let get = warp::get2().and(warp::path("hello").map(warp::reply));
     let post = warp::post2().and(warp::path("bye").map(warp::reply));
 
@@ -39,6 +42,7 @@ fn method_not_allowed_trumps_not_found() {
 
 #[test]
 fn bad_request_trumps_method_not_allowed() {
+    let _ = pretty_env_logger::try_init();
     let get = warp::get2()
         .and(warp::path("hello"))
         .and(warp::header::exact("foo", "bar"))

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -4,6 +4,7 @@ extern crate warp;
 extern crate serde_derive;
 
 use std::collections::HashMap;
+use warp::Filter;
 
 #[test]
 fn query() {
@@ -80,13 +81,15 @@ fn missing_required_query_struct_partial() {
 
 #[test]
 fn missing_required_query_struct_no_query() {
-    let as_struct = warp::query::<MyRequiredArgs>();
+    let as_struct = warp::query::<MyRequiredArgs>()
+        .map(|_| warp::reply());
 
     let req = warp::test::request()
         .path("/");
 
-    let extracted = req.filter(&as_struct);
-    assert!(extracted.is_err())
+    let res = req.reply(&as_struct);
+    assert_eq!(res.status(), 400);
+    assert_eq!(res.body(), "Invalid query string");
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]


### PR DESCRIPTION
The `Rejection` type can now nest and combine arbitrary rejections,
so it is no longer bound to a small set of meanings. The ranking of
status codes is still used to determine which rejection gets priority.

A different priority can be implemented by handling rejections with
a `Filter::recover`, and searching for causes in order via
`Rejection::find_cause`.

- Adds `warp::reject::custom()` to create a `Rejection` with
  any `Into<Box<std::error::Error>>`. These rejections should be
  handled with an eventual `Filter::recover`. Any unhandled
  custom rejections are considered a server error.
- Deprecates `Rejection::with`. Use custom rejections instead.
- Deprecates `Rejection::into_cause`, as it can no longer work. Always
  returns `Err(Rejection)`.
- Deprecates `Rejection::json`, since the format needed is too generic.
  The `errors.rs` example shows how to send custom JSON when recovering
  from rejections.
- Deprecates `warp::reject()`, since it current signals a `400 Bad
  Request`, but in newer versions, it will signal `404 Not Found`.
  It's deprecated simply to warn that the semantics are changing,
  but the function won't actually go away.
- Deprecates `reject::bad_request()`, `reject::forbidden()`, and
  `reject::server_error()`. Uses custom rejections instead.