### PR TITLE
Implement ReplySealed for Result<impl Reply, impl Reply>

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -373,6 +373,20 @@ mod sealed {
         }
     }
 
+    impl<T, T2> ReplySealed for Result<T, T2>
+    where
+        T: Reply + Send,
+        T2: Reply + Send,
+    {
+        #[inline]
+        fn into_response(self) -> Response {
+            match self {
+                Ok(t) => t.into_response(),
+                Err(e) => e.into_response(),
+            }
+        }
+    }
+
     impl<T> ReplySealed for Result<T, ::http::Error>
     where
         T: Reply + Send,


### PR DESCRIPTION
Edit: I now realize that `Rejection` is probably the intended type for failures, 
but as was noted in other issues, this badly needs a way to have full customizability for the error response.

This makes returning customized error responses much more convenient
by preventing the need to return Box<impl Reply> from a filter.

There might of course be reasons why this is not already here or not wanted but to me it seems very nice to have.

eg:

```rust
....map(|user_id| {
    db.user(user_id)
      .map(|user| reply::json(&user))
      .map_err(convert_err_to_reply)
})
```