### PR TITLE
Server-sent events for warp

### DIFF
--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -9,17 +9,19 @@ use warp::{Filter, Stream};
 fn main() {
     pretty_env_logger::init();
 
-    let routes = warp::path("ticks").and(warp::get2()).map(|| {
-        let mut counter: u64 = 0;
-        // create server event source
-        let event_stream = Interval::new(now(), Duration::from_secs(1)).map(move |_| {
-            counter += 1;
-            // create server-sent event
-            warp::sse::data(counter)
+    let routes = warp::path("ticks")
+        .and(warp::sse())
+        .map(|sse: warp::sse::Sse| {
+            let mut counter: u64 = 0;
+            // create server event source
+            let event_stream = Interval::new(now(), Duration::from_secs(1)).map(move |_| {
+                counter += 1;
+                // create server-sent event
+                warp::sse::data(counter)
+            });
+            // reply using server-sent events
+            sse.reply(event_stream)
         });
-        // reply using server-sent events
-        warp::sse(event_stream)
-    });
 
     warp::serve(routes).run(([127, 0, 0, 1], 3030));
 }

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -1,0 +1,25 @@
+extern crate pretty_env_logger;
+extern crate tokio;
+extern crate warp;
+
+use std::time::Duration;
+use tokio::{clock::now, timer::Interval};
+use warp::{Filter, Stream};
+
+fn main() {
+    pretty_env_logger::init();
+
+    let routes = warp::path("ticks").and(warp::get2()).map(|| {
+        let mut counter: u64 = 0;
+        // create server event source
+        let event_stream = Interval::new(now(), Duration::from_secs(1)).map(move |_| {
+            counter += 1;
+            // create server-sent event
+            warp::sse::data(counter)
+        });
+        // reply using server-sent events
+        warp::sse(event_stream)
+    });
+
+    warp::serve(routes).run(([127, 0, 0, 1], 3030));
+}

--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -1,0 +1,197 @@
+extern crate futures;
+extern crate pretty_env_logger;
+extern crate warp;
+
+use futures::{
+    future::poll_fn,
+    sync::{mpsc, oneshot},
+    Future, Stream,
+};
+use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
+use warp::{Buf, Filter, ServerSentEvent};
+
+/// Our global unique user id counter.
+static NEXT_USER_ID: AtomicUsize = AtomicUsize::new(1);
+
+/// Message variants.
+enum Message {
+    UserId(usize),
+    Reply(String),
+}
+
+/// Our state of currently connected users.
+///
+/// - Key is their id
+/// - Value is a sender of `Message`
+type Users = Arc<Mutex<HashMap<usize, mpsc::UnboundedSender<Message>>>>;
+
+fn main() {
+    pretty_env_logger::init();
+
+    // Keep track of all connected users, key is usize, value
+    // is a event stream sender.
+    let users = Arc::new(Mutex::new(HashMap::new()));
+    // Turn our "state" into a new Filter...
+    let users = warp::any().map(move || users.clone());
+
+    // POST /chat -> send message
+    let chat_send = warp::path("chat")
+        .and(warp::post2())
+        .and(warp::path::param::<usize>())
+        .and(warp::body::content_length_limit(500))
+        .and(warp::body::concat().and_then(|body: warp::body::FullBody| {
+            std::str::from_utf8(body.bytes())
+                .map(String::from)
+                .map_err(warp::reject::custom)
+        })).and(users.clone())
+        .map(|my_id, msg, users| {
+            user_message(my_id, msg, &users);
+            warp::reply()
+        });
+
+    // GET /chat -> messages stream
+    let chat_recv = warp::path("chat")
+        .and(warp::get2())
+        .and(users)
+        .map(|users| {
+            // reply using server-sent events
+            let stream = user_connected(users);
+            warp::sse(warp::sse::keep(stream, None))
+        });
+
+    // GET / -> index html
+    let index = warp::path::end().map(|| {
+        warp::http::Response::builder()
+            .header("content-type", "text/html; charset=utf-8")
+            .body(INDEX_HTML)
+    });
+
+    let routes = index.or(chat_recv).or(chat_send);
+
+    warp::serve(routes).run(([127, 0, 0, 1], 3030));
+}
+
+fn user_connected(
+    users: Users,
+) -> impl Stream<Item = impl ServerSentEvent + Send + 'static, Error = warp::Error> + Send + 'static
+{
+    // Use a counter to assign a new unique ID for this user.
+    let my_id = NEXT_USER_ID.fetch_add(1, Ordering::Relaxed);
+
+    eprintln!("new chat user: {}", my_id);
+
+    // Use an unbounded channel to handle buffering and flushing of messages
+    // to the event source...
+    let (tx, rx) = mpsc::unbounded();
+
+    match tx.unbounded_send(Message::UserId(my_id)) {
+        Ok(()) => (),
+        Err(_disconnected) => {
+            // The tx is disconnected, our `user_disconnected` code
+            // should be happening in another task, nothing more to
+            // do here.
+        }
+    }
+
+    // Make an extra clone of users list to give to our disconnection handler...
+    let users2 = users.clone();
+
+    // Save the sender in our list of connected users.
+    users.lock().unwrap().insert(my_id, tx);
+
+    // Create channel to track disconnecting the receiver side of events.
+    // This is little bit tricky.
+    let (mut dtx, mut drx) = oneshot::channel::<()>();
+
+    // When `drx` will dropped then `dtx` will be canceled.
+    // We can track it to make sure when the user leaves chat.
+    warp::spawn(poll_fn(move || dtx.poll_cancel()).map(move |_| {
+        user_disconnected(my_id, &users2);
+    }));
+
+    // Convert messages into Server-Sent Events and return resulting stream.
+    rx.map(|msg| match msg {
+        Message::UserId(my_id) => (warp::sse::event("user"), warp::sse::data(my_id)).into_a(),
+        Message::Reply(reply) => warp::sse::data(reply).into_b(),
+    }).map_err(move |_| {
+        // Keep `drx` alive until `rx` will be closed
+        drx.close();
+        unreachable!("unbounded rx never errors");
+    })
+}
+
+fn user_message(my_id: usize, msg: String, users: &Users) {
+    let new_msg = format!("<User#{}>: {}", my_id, msg);
+
+    // New message from this user, send it to everyone else (except same uid)...
+    //
+    // We use `retain` instead of a for loop so that we can reap any user that
+    // appears to have disconnected.
+    for (&uid, tx) in users.lock().unwrap().iter() {
+        if my_id != uid {
+            match tx.unbounded_send(Message::Reply(new_msg.clone())) {
+                Ok(()) => (),
+                Err(_disconnected) => {
+                    // The tx is disconnected, our `user_disconnected` code
+                    // should be happening in another task, nothing more to
+                    // do here.
+                }
+            }
+        }
+    }
+}
+
+fn user_disconnected(my_id: usize, users: &Users) {
+    eprintln!("good bye user: {}", my_id);
+
+    // Stream closed up, so remove from the user list
+    users.lock().unwrap().remove(&my_id);
+}
+
+static INDEX_HTML: &str = r#"
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Warp Chat</title>
+    </head>
+    <body>
+        <h1>warp chat</h1>
+        <div id="chat">
+            <p><em>Connecting...</em></p>
+        </div>
+        <input type="text" id="text" />
+        <button type="button" id="send">Send</button>
+        <script type="text/javascript">
+        var uri = 'http://' + location.host + '/chat';
+        var sse = new EventSource(uri);
+        function message(data) {
+            var line = document.createElement('p');
+            line.innerText = data;
+            chat.appendChild(line);
+        }
+        sse.onopen = function() {
+            chat.innerHTML = "<p><em>Connected!</em></p>";
+        }
+        var user_id;
+        sse.addEventListener("user", function(msg) {
+            user_id = msg.data;
+        });
+        sse.onmessage = function(msg) {
+            message(msg.data);
+        };
+        send.onclick = function() {
+            var msg = text.value;
+            var xhr = new XMLHttpRequest();
+            xhr.open("POST", uri + '/' + user_id, true);
+            xhr.send(msg);
+            text.value = '';
+            message('<You>: ' + msg);
+        };
+        </script>
+    </body>
+</html>
+"#;

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -14,6 +14,7 @@ pub mod method;
 pub mod path;
 pub mod query;
 pub mod reply;
+pub mod sse;
 pub mod ws;
 
 pub use ::filter::BoxedFilter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ pub mod reject;
 pub mod reply;
 mod route;
 mod server;
+pub mod sse;
 pub mod test;
 
 pub use self::error::Error;
@@ -158,6 +159,8 @@ pub use self::reject::{reject, Rejection};
 #[doc(hidden)]
 pub use self::reply::{reply, Reply};
 pub use self::server::{serve, Server};
+#[doc(hidden)]
+pub use self::sse::{sse, ServerSentEvent};
 pub use hyper::rt::spawn;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,6 @@ pub mod reject;
 pub mod reply;
 mod route;
 mod server;
-pub mod sse;
 pub mod test;
 
 pub use self::error::Error;
@@ -147,6 +146,9 @@ pub use self::filters::{
     query,
     // query() function
     query::query,
+    sse,
+    // sse() function
+    sse::sse,
     ws,
     // ws() function
     ws::{ws, ws2},
@@ -159,8 +161,6 @@ pub use self::reject::{reject, Rejection};
 #[doc(hidden)]
 pub use self::reply::{reply, Reply};
 pub use self::server::{serve, Server};
-#[doc(hidden)]
-pub use self::sse::{sse, ServerSentEvent};
 pub use hyper::rt::spawn;
 
 

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -1,0 +1,595 @@
+//! Reply using Server-Sent Events (SSE) stream.
+//!
+//! # Example
+//!
+//! ```
+//! # extern crate futures;
+//! # extern crate warp;
+//!
+//! use std::time::Duration;
+//! use futures::stream::iter_ok;
+//! use warp::{Filter, ServerSentEvent};
+//!
+//! let app = warp::get2().and(warp::path("push-notifications")).map(|| {
+//!     let events = iter_ok::<_, ::std::io::Error>(vec![
+//!         warp::sse::data("unnamed event").into_a(),
+//!         (
+//!             warp::sse::event("chat"),
+//!             warp::sse::data("chat message"),
+//!         ).into_a().into_b(),
+//!         (
+//!             warp::sse::id(13),
+//!             warp::sse::event("chat"),
+//!             warp::sse::data("other chat message\nwith next line"),
+//!             warp::sse::retry(Duration::from_millis(5000)),
+//!         ).into_b().into_b(),
+//!     ]);
+//!     warp::sse(warp::sse::keep(events, None))
+//! });
+//! ```
+//!
+//! Each field already is event which can be sent to client.
+//! The events with multiple fields can be created by combining fields using tuples.
+//!
+//! See also [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) API.
+//!
+use self::sealed::{SseError, SseField, SseFormat, SseWrapper};
+use filter::One;
+use filters::header::{header, MissingHeader};
+use futures::{Async, Future, Poll, Stream};
+use http::header::{HeaderValue, CACHE_CONTROL, CONTENT_TYPE};
+use hyper::Body;
+use reply::{ReplySealed, Response};
+use serde::Serialize;
+use serde_json;
+use std::error::Error as StdError;
+use std::fmt::{self, Display, Formatter, Write};
+use std::str::FromStr;
+use std::time::Duration;
+use tokio::{clock::now, timer::Delay};
+use {Filter, Rejection, Reply};
+
+/// Server-sent event message
+pub trait ServerSentEvent: SseFormat + Sized + Send + 'static {
+    /// Convert to either A
+    fn into_a<B>(self) -> EitherServerSentEvent<Self, B> {
+        EitherServerSentEvent::A(self)
+    }
+
+    /// Convert to either B
+    fn into_b<A>(self) -> EitherServerSentEvent<A, Self> {
+        EitherServerSentEvent::B(self)
+    }
+
+    /// Convert to boxed
+    fn boxed(self) -> BoxedServerSentEvent {
+        BoxedServerSentEvent(Box::new(self))
+    }
+}
+
+impl<T: SseFormat + Send + 'static> ServerSentEvent for T {}
+
+/// Boxed server-sent event
+#[allow(missing_debug_implementations)]
+pub struct BoxedServerSentEvent(Box<SseFormat + Send>);
+
+impl SseFormat for BoxedServerSentEvent {
+    fn fmt_field(&self, f: &mut Formatter, k: &SseField) -> fmt::Result {
+        self.0.fmt_field(f, k)
+    }
+}
+
+/// Either of two server-sent events
+#[allow(missing_debug_implementations)]
+pub enum EitherServerSentEvent<A, B> {
+    /// Variant A
+    A(A),
+    /// Variant B
+    B(B),
+}
+
+impl<A, B> SseFormat for EitherServerSentEvent<A, B>
+where
+    A: SseFormat,
+    B: SseFormat,
+{
+    fn fmt_field(&self, f: &mut Formatter, k: &SseField) -> fmt::Result {
+        use self::EitherServerSentEvent::*;
+        match self {
+            A(a) => a.fmt_field(f, k),
+            B(b) => b.fmt_field(f, k),
+        }
+    }
+}
+
+#[allow(missing_debug_implementations)]
+struct SseComment<T>(T);
+
+/// Comment field (":<comment-text>")
+pub fn comment<T>(comment: T) -> impl ServerSentEvent
+where
+    T: Display + Send + 'static,
+{
+    SseComment(comment)
+}
+
+impl<T: Display> SseFormat for SseComment<T> {
+    fn fmt_field(&self, f: &mut Formatter, k: &SseField) -> fmt::Result {
+        if let SseField::Comment = k {
+            k.fmt(f)?;
+            self.0.fmt(f)?;
+            f.write_char('\n')?;
+        }
+        Ok(())
+    }
+}
+
+#[allow(missing_debug_implementations)]
+struct SseEvent<T>(T);
+
+/// Event name field ("event:<event-name>")
+pub fn event<T>(event: T) -> impl ServerSentEvent
+where
+    T: Display + Send + 'static,
+{
+    SseEvent(event)
+}
+
+impl<T: Display> SseFormat for SseEvent<T> {
+    fn fmt_field(&self, f: &mut Formatter, k: &SseField) -> fmt::Result {
+        if let SseField::Event = k {
+            k.fmt(f)?;
+            self.0.fmt(f)?;
+            f.write_char('\n')?;
+        }
+        Ok(())
+    }
+}
+
+#[allow(missing_debug_implementations)]
+struct SseId<T>(T);
+
+/// Identifier field ("id:<identifier>")
+pub fn id<T>(id: T) -> impl ServerSentEvent
+where
+    T: Display + Send + 'static,
+{
+    SseId(id)
+}
+
+impl<T: Display> SseFormat for SseId<T> {
+    fn fmt_field(&self, f: &mut Formatter, k: &SseField) -> fmt::Result {
+        if let SseField::Id = k {
+            k.fmt(f)?;
+            self.0.fmt(f)?;
+            f.write_char('\n')?;
+        }
+        Ok(())
+    }
+}
+
+#[allow(missing_debug_implementations)]
+struct SseRetry(Duration);
+
+/// Retry timeout field ("retry:<timeout>")
+pub fn retry(time: Duration) -> impl ServerSentEvent {
+    SseRetry(time)
+}
+
+impl SseFormat for SseRetry {
+    fn fmt_field(&self, f: &mut Formatter, k: &SseField) -> fmt::Result {
+        if let SseField::Retry = k {
+            k.fmt(f)?;
+
+            let secs = self.0.as_secs();
+            let millis = self.0.subsec_nanos() / 1_000_000;
+
+            if secs > 0 {
+                // format seconds
+                secs.fmt(f)?;
+
+                // pad milliseconds
+                if millis < 10 {
+                    f.write_str("00")?;
+                } else if millis < 100 {
+                    f.write_char('0')?;
+                }
+            }
+
+            // format milliseconds
+            millis.fmt(f)?;
+
+            f.write_char('\n')?;
+        }
+        Ok(())
+    }
+}
+
+#[allow(missing_debug_implementations)]
+struct SseData<T>(T);
+
+/// Data field(s) ("data:<content>")
+///
+/// The multiline content will be transferred
+/// using sequential data fields, one per line.
+pub fn data<T>(data: T) -> impl ServerSentEvent
+where
+    T: Display + Send + 'static,
+{
+    SseData(data)
+}
+
+impl<T: Display> SseFormat for SseData<T> {
+    fn fmt_field(&self, f: &mut Formatter, k: &SseField) -> fmt::Result {
+        if let SseField::Data = k {
+            for line in self.0.to_string().split('\n') {
+                k.fmt(f)?;
+                line.fmt(f)?;
+                f.write_char('\n')?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[allow(missing_debug_implementations)]
+struct SseJson<T>(T);
+
+/// Data field with JSON content ("data:<json-content>")
+pub fn json<T>(data: T) -> impl ServerSentEvent
+where
+    T: Serialize + Send + 'static,
+{
+    SseJson(data)
+}
+
+impl<T: Serialize> SseFormat for SseJson<T> {
+    fn fmt_field(&self, f: &mut Formatter, k: &SseField) -> fmt::Result {
+        if let SseField::Data = k {
+            k.fmt(f)?;
+            serde_json::to_string(&self.0)
+                .map_err(|error| {
+                    error!("sse::json error {}", error);
+                    fmt::Error
+                }).and_then(|data| data.fmt(f))?;
+            f.write_char('\n')?;
+        }
+        Ok(())
+    }
+}
+
+macro_rules! tuple_fmt {
+    (($($t:ident),+) => ($($i:tt),+)) => {
+        impl<$($t),+> SseFormat for ($($t),+)
+        where
+            $($t: SseFormat,)+
+        {
+            fn fmt_field(&self, f: &mut Formatter, k: &SseField) -> fmt::Result {
+                $(self.$i.fmt_field(f, k)?;)+
+                Ok(())
+            }
+        }
+    };
+}
+
+tuple_fmt!((A, B) => (0, 1));
+tuple_fmt!((A, B, C) => (0, 1, 2));
+tuple_fmt!((A, B, C, D) => (0, 1, 2, 3));
+tuple_fmt!((A, B, C, D, E) => (0, 1, 2, 3, 4));
+tuple_fmt!((A, B, C, D, E, F) => (0, 1, 2, 3, 4, 5));
+tuple_fmt!((A, B, C, D, E, F, G) => (0, 1, 2, 3, 4, 5, 6));
+tuple_fmt!((A, B, C, D, E, F, G, H) => (0, 1, 2, 3, 4, 5, 6, 7));
+
+/// Gets the optional last event id from request.
+///
+/// ```
+/// let app = warp::sse::last_event_id::<u32>();
+///
+/// // The identifier is present
+/// assert_eq!(
+///     warp::test::request()
+///        .header("Last-Event-ID", "12")
+///        .filter(&app)
+///        .unwrap(),
+///     Some(12)
+/// );
+///
+/// // The identifier is missing
+/// assert_eq!(
+///     warp::test::request()
+///        .filter(&app)
+///        .unwrap(),
+///     None
+/// );
+///
+/// // The identifier is not a valid
+/// assert!(
+///     warp::test::request()
+///        .header("Last-Event-ID", "abc")
+///        .filter(&app)
+///        .is_err(),
+/// );
+/// ```
+pub fn last_event_id<T>() -> impl Filter<Extract = One<Option<T>>, Error = Rejection>
+where
+    T: FromStr + Send,
+{
+    header("Last-Event-ID")
+        .map(Some)
+        .or_else(|rejection: Rejection| {
+            if rejection.find_cause::<MissingHeader>().is_some() {
+                return Ok((None,));
+            }
+            Err(rejection)
+        })
+}
+
+/// Server-sent events reply
+///
+/// This function converts stream of server events into reply.
+///
+/// ```
+/// # extern crate futures;
+/// # extern crate warp;
+/// # extern crate serde;
+/// # #[macro_use] extern crate serde_derive;
+///
+/// use std::time::Duration;
+/// use futures::stream::iter_ok;
+/// use warp::{Filter, ServerSentEvent};
+///
+/// #[derive(Serialize)]
+/// struct Msg {
+///     from: u32,
+///     text: String,
+/// }
+///
+/// let app = warp::get2().and(warp::path("sse")).map(|| {
+///     let events = iter_ok::<_, ::std::io::Error>(vec![
+///         // Unnamed event with data only
+///         warp::sse::data("payload").boxed(),
+///         // Named event with ID and retry timeout
+///         (
+///             warp::sse::data("other message\nwith next line"),
+///             warp::sse::event("chat"),
+///             warp::sse::id(1),
+///             warp::sse::retry(Duration::from_millis(15000))
+///         ).boxed(),
+///         // Event with JSON data
+///         (
+///             warp::sse::id(2),
+///             warp::sse::json(Msg {
+///                 from: 2,
+///                 text: "hello".into(),
+///             }),
+///         ).boxed(),
+///     ]);
+///     warp::sse(events)
+/// });
+///
+/// let res = warp::test::request()
+///     .method("GET")
+///     .path("/sse")
+///     .reply(&app)
+///     .into_body();
+///
+/// assert_eq!(
+///     res,
+///     r#"data:payload
+///
+/// event:chat
+/// data:other message
+/// data:with next line
+/// id:1
+/// retry:15000
+///
+/// data:{"from":2,"text":"hello"}
+/// id:2
+///
+/// "#
+/// );
+/// ```
+pub fn sse<S>(event_stream: S) -> impl Reply
+where
+    S: Stream + Send + 'static,
+    S::Item: ServerSentEvent,
+    S::Error: StdError + Send + Sync + 'static,
+{
+    SseReply { event_stream }
+}
+
+#[allow(missing_debug_implementations)]
+struct SseReply<S> {
+    event_stream: S,
+}
+
+impl<S> ReplySealed for SseReply<S>
+where
+    S: Stream + Send + 'static,
+    S::Item: ServerSentEvent,
+    S::Error: StdError + Send + Sync + 'static,
+{
+    #[inline]
+    fn into_response(self) -> Response {
+        let mut res = Response::new(Body::wrap_stream(
+            self.event_stream
+                // FIXME: error logging
+                .map_err(|error| {
+                    error!("sse stream error: {}", error);
+                    SseError
+                }).and_then(|event| SseWrapper::format(&event)),
+        ));
+        {
+            let headers = res.headers_mut();
+            // Set appropriate content type
+            headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+            // Disable response body caching
+            headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+        }
+        res
+    }
+}
+
+#[allow(missing_debug_implementations)]
+struct SseKeepAlive<S> {
+    event_stream: S,
+    max_interval: Duration,
+    alive_timer: Delay,
+}
+
+/// Keeps event source connection when no events sent over a some time.
+///
+/// Some proxy servers may drop HTTP connection after a some timeout of inactivity.
+/// This function helps to prevent such behavior by sending dummy events with single
+/// empty comment field (i.e. ":" only) each `keep_interval` of inactivity.
+///
+/// See [notes](https://www.w3.org/TR/2009/WD-eventsource-20090421/#notes).
+pub fn keep<S>(
+    event_stream: S,
+    keep_interval: Option<Duration>,
+) -> impl Stream<
+    Item = impl ServerSentEvent + Send + 'static,
+    Error = impl StdError + Send + Sync + 'static,
+> + Send
+         + 'static
+where
+    S: Stream + Send + 'static,
+    S::Item: ServerSentEvent + Send,
+    S::Error: StdError + Send + Sync + 'static,
+{
+    let max_interval = keep_interval.unwrap_or_else(|| Duration::from_secs(15));
+    let alive_timer = Delay::new(now() + max_interval);
+    SseKeepAlive {
+        event_stream,
+        max_interval,
+        alive_timer,
+    }
+}
+
+impl<S> Stream for SseKeepAlive<S>
+where
+    S: Stream + Send + 'static,
+    S::Item: ServerSentEvent,
+    S::Error: StdError + Send + Sync + 'static,
+{
+    type Item = EitherServerSentEvent<S::Item, SseComment<&'static str>>;
+    type Error = SseError;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        match self.event_stream.poll() {
+            Ok(Async::NotReady) => match self.alive_timer.poll() {
+                Ok(Async::NotReady) => Ok(Async::NotReady),
+                Ok(Async::Ready(_)) => {
+                    // restart timer
+                    self.alive_timer.reset(now() + self.max_interval);
+                    Ok(Async::Ready(Some(EitherServerSentEvent::B(SseComment("")))))
+                }
+                Err(error) => {
+                    error!("sse::keep error: {}", error);
+                    Err(SseError)
+                }
+            },
+            Ok(Async::Ready(Some(event))) => {
+                // restart timer
+                self.alive_timer.reset(now() + self.max_interval);
+                Ok(Async::Ready(Some(EitherServerSentEvent::A(event))))
+            }
+            Ok(Async::Ready(None)) => Ok(Async::Ready(None)),
+            Err(error) => {
+                error!("sse::keep error: {}", error);
+                Err(SseError)
+            }
+        }
+    }
+}
+
+mod sealed {
+    use super::*;
+
+    /// SSE error type
+    #[derive(Debug)]
+    pub struct SseError;
+
+    impl Display for SseError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            write!(f, "sse error")
+        }
+    }
+
+    impl StdError for SseError {
+        fn description(&self) -> &str {
+            "sse error"
+        }
+    }
+
+    impl Display for SseField {
+        fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+            use self::SseField::*;
+            f.write_str(match self {
+                Event => "event:",
+                Id => "id:",
+                Data => "data:",
+                Retry => "retry:",
+                Comment => ":",
+            })
+        }
+    }
+
+    /// SSE field kind
+    #[allow(missing_debug_implementations)]
+    pub enum SseField {
+        /// Event name field
+        Event,
+        /// Event id field
+        Id,
+        /// Event data field
+        Data,
+        /// Retry timeout field
+        Retry,
+        /// Comment field
+        Comment,
+    }
+
+    /// SSE formatter trait
+    pub trait SseFormat {
+        /// format message field
+        fn fmt_field(&self, _f: &mut Formatter, _key: &SseField) -> fmt::Result {
+            Ok(())
+        }
+    }
+
+    /// SSE wrapper to help formatting messages
+    #[allow(missing_debug_implementations)]
+    pub struct SseWrapper<'a, T: 'a>(&'a T);
+
+    impl<'a, T> SseWrapper<'a, T>
+    where
+        T: SseFormat + 'a,
+    {
+        pub fn format(event: &'a T) -> Result<String, SseError> {
+            let mut buf = String::new();
+            buf.write_fmt(format_args!("{}", SseWrapper(event)))
+                .map_err(|_| SseError)?;
+            buf.shrink_to_fit();
+            Ok(buf)
+        }
+    }
+
+    impl<'a, T> Display for SseWrapper<'a, T>
+    where
+        T: SseFormat,
+    {
+        fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+            self.0.fmt_field(f, &SseField::Comment)?;
+            // The event name usually transferred before the other fields.
+            self.0.fmt_field(f, &SseField::Event)?;
+            // It is important that the data will be transferred before
+            // the identifier to prevent possible losing events when
+            // resuming connection.
+            self.0.fmt_field(f, &SseField::Data)?;
+            self.0.fmt_field(f, &SseField::Id)?;
+            self.0.fmt_field(f, &SseField::Retry)?;
+            f.write_char('\n')
+        }
+    }
+}


### PR DESCRIPTION
Helps turning server events stream into *SSE* reply.

If it's not reasonable to merge this functionality with warp,
I would like to create different crate but I have some troubles with it.