### PR TITLE
Add  `warp::addr::remote()` filter.

### DIFF
--- a/src/filter/service.rs
+++ b/src/filter/service.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use futures::{Future, Poll};
 
 use ::{Filter, Request};
@@ -20,10 +22,10 @@ where
     type Reply = FilteredFuture<F::Future>;
 
     #[inline]
-    fn call(&self, req: Request) -> Self::Reply {
+    fn call(&self, req: Request, remote_addr: Option<SocketAddr>) -> Self::Reply {
         debug_assert!(!route::is_set(), "nested route::set calls");
 
-        let route = Route::new(req);
+        let route = Route::new(req, remote_addr);
         let fut = route::set(&route, || self.filter.filter());
         FilteredFuture {
             future: fut,

--- a/src/filters/addr.rs
+++ b/src/filters/addr.rs
@@ -1,0 +1,28 @@
+//! Socket Address filters.
+
+use std::net::SocketAddr;
+
+use ::filter::{Filter, filter_fn_one};
+use ::never::Never;
+
+/// Creates a `Filter` to get the remote address of the connection.
+///
+/// If the underlying transport doesn't use socket addresses, this will yield
+/// `None`.
+///
+/// # Example
+///
+/// ```
+/// use std::net::SocketAddr;
+/// use warp::Filter;
+///
+/// let route = warp::addr::remote()
+///     .map(|addr: Option<SocketAddr>| {
+///         println!("remote address = {:?}", addr);
+///     });
+/// ```
+pub fn remote() -> impl Filter<Extract=(Option<SocketAddr>,), Error=Never> + Copy {
+    filter_fn_one(|route| {
+        Ok(route.remote_addr())
+    })
+}

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -3,6 +3,7 @@
 //! This module mostly serves as documentation to group together the list of
 //! built-in filters. Most of these are available at more convenient paths.
 
+pub mod addr;
 pub mod any;
 pub mod body;
 pub mod cookie;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ mod route;
 mod server;
 pub mod test;
 #[cfg(feature = "tls")] mod tls;
+mod transport;
 
 pub use self::error::Error;
 pub use self::filter::{Filter};
@@ -126,6 +127,7 @@ pub use self::filter::{Filter};
 pub use self::filters::{
     // any() function
     any::any,
+    addr,
     body,
     cookie,
     // cookie() function

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,10 +1,13 @@
 use std::fs::File;
 use std::io::{self, BufReader, Read, Write};
+use std::net::SocketAddr;
 use std::path::Path;
 
 use futures::Poll;
 use rustls::{self, Session, ServerConfig, ServerSession, Stream};
 use tokio_io::{AsyncRead, AsyncWrite};
+
+use transport::Transport;
 
 pub(crate) fn configure(cert: &Path, key: &Path) -> ServerConfig {
 
@@ -112,3 +115,10 @@ impl<T: AsyncRead + AsyncWrite> AsyncWrite for TlsStream<T> {
         self.io.shutdown()
     }
 }
+
+impl<T: Transport> Transport for TlsStream<T> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        self.io.remote_addr()
+    }
+}
+

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,54 @@
+use std::net::SocketAddr;
+use std::io::{self, Read, Write};
+
+use bytes::Buf;
+use futures::Poll;
+use hyper::server::conn::AddrStream;
+use tokio_io::{AsyncRead, AsyncWrite};
+
+pub trait Transport: AsyncRead + AsyncWrite {
+    fn remote_addr(&self) -> Option<SocketAddr>;
+}
+
+impl Transport for AddrStream {
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        Some(self.remote_addr())
+    }
+}
+
+pub(crate) struct LiftIo<T>(pub(crate) T);
+
+impl<T: Read> Read for LiftIo<T> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl<T: Write> Write for LiftIo<T> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<T: AsyncRead> AsyncRead for LiftIo<T> {
+}
+
+impl<T: AsyncWrite> AsyncWrite for LiftIo<T> {
+    fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        self.0.write_buf(buf)
+    }
+
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        self.0.shutdown()
+    }
+}
+
+impl<T: AsyncRead + AsyncWrite> Transport for LiftIo<T> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        None
+    }
+}


### PR DESCRIPTION
Returns the socket address of the immediate connection, if the transport
type supports socket addresses.

Closes #9