### PR TITLE
Replicate traits from protocol::Message on Message

### DIFF
--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -354,6 +354,7 @@ impl fmt::Debug for WebSocket {
 ///
 /// This will likely become a `non-exhaustive` enum in the future, once that
 /// language feature has stabilized.
+#[derive(Eq, PartialEq, Clone)]
 pub struct Message {
     inner: protocol::Message,
 }


### PR DESCRIPTION
Tungstenite's `Message` implements `Clone`, but the wrapper in Warp does not. You don't run into this in your websocket chat example because you run the Message through Display first, and clone the string.