### PR TITLE
add graceful shutdown example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ urlencoding = "1.0.0"
 pretty_env_logger = "0.2"
 serde_derive = "1.0"
 handlebars = "1.0.0"
+signal-hook = { version = "0.1", features = ["tokio-support"] }
 
 [features]
 tls = ["rustls"]

--- a/examples/graceful_shutdown.rs
+++ b/examples/graceful_shutdown.rs
@@ -1,0 +1,38 @@
+#![deny(warnings)]
+
+#[macro_use]
+extern crate log;
+
+extern crate futures;
+extern crate pretty_env_logger;
+extern crate signal_hook;
+extern crate tokio;
+extern crate warp;
+
+use futures::future::Future;
+use futures::stream::Stream;
+use signal_hook::iterator::Signals;
+use warp::Filter;
+
+fn main() {
+    pretty_env_logger::init();
+    let routes = warp::any().map(|| {
+        std::thread::sleep(std::time::Duration::from_secs(5));
+        "slept for 5 seconds\n"
+    });
+
+    let shutdown = Signals::new(&[signal_hook::SIGINT, signal_hook::SIGTERM])
+        .expect("successful signal registration")
+        .into_async()
+        .expect("successful async conversion")
+        .into_future()
+        .map(|_sig| info!("shutdown requested"))
+        .map_err(|e| panic!("signal error {}", e.0));
+
+    let port = 3030;
+    info!("now serving on http://127.0.0.1:{}/", port);
+    let (_addr, server) =
+        warp::serve(routes).bind_with_graceful_shutdown(([127, 0, 0, 1], port), shutdown);
+    tokio::run(server);
+    info!("clean shutdown completed");
+}


### PR DESCRIPTION
Provides a more complete example using an external `signal-hooks` crate that shows how to trigger a clean shutdown for the common case of unix signals.