### PR TITLE
impls ReplySealed for Vec<u8> and &'static [u8].

### DIFF
--- a/src/reject.rs
+++ b/src/reject.rs
@@ -414,8 +414,10 @@ impl Rejections {
             Rejections::Known(ref e) => {
                 let mut res = http::Response::new(Body::from(e.to_string()));
                 *res.status_mut() = self.status();
-                res.headers_mut()
-                    .insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+                res.headers_mut().insert(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("text/plain; charset=utf-8"),
+                );
                 res
             }
             Rejections::KnownStatus(ref s) => {
@@ -426,8 +428,10 @@ impl Rejections {
                 let mut res = rej.into_response();
 
                 let bytes = e.to_string();
-                res.headers_mut()
-                    .insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+                res.headers_mut().insert(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("text/plain; charset=utf-8"),
+                );
                 *res.body_mut() = Body::from(bytes);
 
                 res
@@ -440,8 +444,10 @@ impl Rejections {
                 let body = format!("Unhandled rejection: {}", e);
                 let mut res = http::Response::new(Body::from(body));
                 *res.status_mut() = self.status();
-                res.headers_mut()
-                    .insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+                res.headers_mut().insert(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("text/plain; charset=utf-8"),
+                );
                 res
             }
             Rejections::Combined(ref a, ref b) => preferred(a, b).into_response(),
@@ -745,7 +751,10 @@ mod tests {
     fn into_response_with_some_cause() {
         let resp = server_error().with("boom").into_response();
         assert_eq!(500, resp.status());
-        assert_eq!("text/plain", resp.headers().get(CONTENT_TYPE).unwrap());
+        assert_eq!(
+            "text/plain; charset=utf-8",
+            resp.headers().get(CONTENT_TYPE).unwrap()
+        );
         assert_eq!("boom", response_body_string(resp))
     }
 

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -455,7 +455,21 @@ mod sealed {
         }
     }
 
+    impl ReplySealed for Vec<u8> {
+        #[inline]
+        fn into_response(self) -> Response {
+            Response::new(Body::from(self))
+        }
+    }
+
     impl ReplySealed for &'static str {
+        #[inline]
+        fn into_response(self) -> Response {
+            Response::new(Body::from(self))
+        }
+    }
+
+    impl ReplySealed for &'static [u8] {
         #[inline]
         fn into_response(self) -> Response {
             Response::new(Body::from(self))

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -368,7 +368,7 @@ mod sealed {
     use generic::{Either, One};
     use reject::Reject;
 
-    use super::Reply;
+    use super::{HeaderValue, Reply, CONTENT_TYPE};
 
     pub type Response = ::http::Response<Body>;
 
@@ -451,28 +451,52 @@ mod sealed {
     impl ReplySealed for String {
         #[inline]
         fn into_response(self) -> Response {
-            Response::new(Body::from(self))
+            ::http::Response::builder()
+                .header(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("text/plain; charset=utf-8"),
+                )
+                .body(Body::from(self))
+                .unwrap()
         }
     }
 
     impl ReplySealed for Vec<u8> {
         #[inline]
         fn into_response(self) -> Response {
-            Response::new(Body::from(self))
+            ::http::Response::builder()
+                .header(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("application/octet-stream"),
+                )
+                .body(Body::from(self))
+                .unwrap()
         }
     }
 
     impl ReplySealed for &'static str {
         #[inline]
         fn into_response(self) -> Response {
-            Response::new(Body::from(self))
+            ::http::Response::builder()
+                .header(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("text/plain; charset=utf-8"),
+                )
+                .body(Body::from(self))
+                .unwrap()
         }
     }
 
     impl ReplySealed for &'static [u8] {
         #[inline]
         fn into_response(self) -> Response {
-            Response::new(Body::from(self))
+            ::http::Response::builder()
+                .header(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("application/octet-stream"),
+                )
+                .body(Body::from(self))
+                .unwrap()
         }
     }
 


### PR DESCRIPTION
what it says on the tin.

tbh, would it make sense to `impl<T: Into<hyper::Body>> ReplySealed for T`?