### PR TITLE
Add a `multi_param` filter constructor for multiple-valued path parameters

### DIFF
--- a/examples/path.rs
+++ b/examples/path.rs
@@ -1,0 +1,32 @@
+#![deny(warnings)]
+extern crate warp;
+
+use warp::{path, Filter};
+
+fn main() {
+    // Match a single parameter
+    // e.g. `/add_3/39` returns "42"
+    let one = path!("add_3" / usize).map(|num| format!("{}", num + 3));
+
+    // Match two parameters in different segments
+    // e.g. `/pythag/5/and/12` returns "13"
+    let two =
+        path!("pythag" / f64 / "and" / f64).map(|num0: f64, num1| format!("{}", num0.hypot(num1)));
+
+    // Match an arbitrary number of parameters of the same type, comma-separated
+    // e.g. `/upper_case/i,love,rust` returns "I, LOVE, RUST"
+    let list = path!("upper_case" / [String]).map(|v: Vec<String>| {
+        let upper_cased = v
+            .iter()
+            .map(String::as_str)
+            .map(str::to_uppercase)
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        format!("{}", upper_cased)
+    });
+
+    let routes = one.or(two).or(list);
+
+    warp::serve(routes).run(([127, 0, 0, 1], 3030));
+}

--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -497,7 +497,10 @@ fn path_and_query(route: &Route) -> PathAndQuery {
 /// Any number of either type identifiers or string expressions can be passed,
 /// each separated by a forward slash (`/`). Strings will be used to match
 /// path segments exactly, and type identifiers are used just like
-/// [`param`](filters::path::param) filters.
+/// [`param`](filters::path::param) filters. If a type parameter is wrapped in
+/// square brackets, it will accept a comma-delimited list of values and be
+/// returned as a `Vec` of that type, just like
+/// [`multi_param`](filters::path::multi_param) filters.
 ///
 /// # Example
 ///
@@ -536,6 +539,9 @@ macro_rules! path {
         )*
         __p
     });
+    (@segment [$param:ty]) => (
+        $crate::path::multi_param::<$param>()
+    );
     (@segment $param:ty) => (
         $crate::path::param::<$param>()
     );


### PR DESCRIPTION
I ran into a spot where I wanted to add an endpoint that looked like `/foo,bar,.../do_baz` - this seemed like a pretty simple logical extension of accepting one parameter. What I had to do with the current API is sort of clunky, and needed to be done for each endpoint that required it:

```rust
let do_foo = warp::path::param().and_then(|thing: String| {
    match thing.split(',').map(MyType::from_str).collect::<Result<Vec<_>, _>>() {
        Ok(ok) => Ok(ok),
        Err(err) => Err(warp::reject::custom(err)),
    }
});
```

This feels like a common enough pattern to include as a filter, and it doesn't end up being all that much code.

What I'm not toooootally sure about is the macro syntax. I added a branch to the `path!` macro with the syntax `[<type>]` to represent a multiple-valued segment - I'd like to know if that's valuable, if it should be changed to a different idiom, or if I should just throw it in the trash. (Small aside: I know that `[type]` means an array of unspecified size, but that's not an issue because those can't be passed as function params.)

Thanks! I really like working with this library, and I'm excited to have something to contribute.