### PR TITLE
Configurable tls support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### v0.2.0 (March 20, 2019)
+
+- **Features**:
+  - Configurable tls support
+
+- **Changes**
+  - Expose `tls` module
+  - Add `tls::config`, `tls::config_from_path`, `tls::config_from_der_data`
+  - Change `tls` method of `wrap::Server` to take `ServerConfig` instead of path only
+  - Removed `tls::configure` function
+
 ### v0.1.14 (March 19, 2019)
 
 - **Features**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
-### v0.2.0 (March 20, 2019)
+### v0.1.15 (March 20, 2019)
 
 - **Features**:
   - Configurable tls support
 
 - **Changes**
   - Expose `tls` module
-  - Add `tls::config`, `tls::config_from_path`, `tls::config_from_der_data`
-  - Change `tls` method of `wrap::Server` to take `ServerConfig` instead of path only
-  - Removed `tls::configure` function
+  - Add `tls::config`, `tls::config_from_path`, `tls::config_from_der_data`.
+  - Add `tls2` method on `warp::Server` to take `ServerConfig` instead of path only
+    `tls` variant.
+  - `tls::configure` has been deprecated
+  - `tls` method of `warp::Server` has been deprecated.
 
 ### v0.1.14 (March 19, 2019)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warp"
-version = "0.2.0" # don't forget to update html_root_url
+version = "0.1.15" # don't forget to update html_root_url
 description = "serve the web at warp speeds"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warp"
-version = "0.1.14" # don't forget to update html_root_url
+version = "0.2.0" # don't forget to update html_root_url
 description = "serve the web at warp speeds"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 license = "MIT"

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -6,12 +6,13 @@ extern crate warp;
 #[cfg(feature = "tls")]
 fn main() {
     use warp::Filter;
+    use warp::tls;
 
     // Match any request and return hello world!
     let routes = warp::any().map(|| "Hello, World!");
 
     warp::serve(routes)
-        .tls("examples/tls/cert.pem", "examples/tls/key.rsa")
+        .tls(tls::config_from_path("examples/tls/cert.pem", "examples/tls/key.rsa"))
         .run(([127, 0, 0, 1], 3030));
 }
 

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -12,7 +12,7 @@ fn main() {
     let routes = warp::any().map(|| "Hello, World!");
 
     warp::serve(routes)
-        .tls(tls::config_from_path("examples/tls/cert.pem", "examples/tls/key.rsa"))
+        .tls2(tls::config_from_path("examples/tls/cert.pem", "examples/tls/key.rsa"))
         .run(([127, 0, 0, 1], 3030));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/warp/0.1.14")]
+#![doc(html_root_url = "https://docs.rs/warp/0.2.0")]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/warp/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/warp/0.1.15")]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ mod route;
 mod server;
 pub mod test;
 #[cfg(feature = "tls")]
-mod tls;
+pub mod tls;
 mod transport;
 
 pub use self::error::Error;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,4 @@
 use std::net::SocketAddr;
-#[cfg(feature = "tls")]
-use std::path::Path;
 use std::sync::Arc;
 
 use futures::{Async, Future, Poll, Stream};
@@ -245,10 +243,8 @@ where
     ///
     /// *This function requires the `"tls"` feature.*
     #[cfg(feature = "tls")]
-    pub fn tls(self, cert: impl AsRef<Path>, key: impl AsRef<Path>) -> TlsServer<S> {
-        let tls = ::tls::configure(cert.as_ref(), key.as_ref());
-
-        TlsServer { server: self, tls }
+    pub fn tls(self, config: rustls::ServerConfig) -> TlsServer<S> {
+        TlsServer { server: self, tls: config }
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -243,7 +243,18 @@ where
     ///
     /// *This function requires the `"tls"` feature.*
     #[cfg(feature = "tls")]
-    pub fn tls(self, config: rustls::ServerConfig) -> TlsServer<S> {
+    #[doc(hidden)]
+    #[deprecated(note = "warp::tls2() is meant to replace tls()")]
+    pub fn tls(self, cert: impl AsRef<std::path::Path>, key: impl AsRef<std::path::Path>) -> TlsServer<S> {
+        let tls = ::tls::configure(cert.as_ref(), key.as_ref());
+        TlsServer { server: self, tls }
+    }
+
+    /// Configure a server to use TLS.
+    ///
+    /// *This function requires the `"tls"` feature.*
+    #[cfg(feature = "tls")]
+    pub fn tls2(self, config: rustls::ServerConfig) -> TlsServer<S> {
         TlsServer { server: self, tls: config }
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -67,6 +67,10 @@ pub fn config(cert_chain: Vec<rustls::Certificate>, key: rustls::PrivateKey) -> 
     tls
 }
 
+pub(crate) fn configure(cert: &Path, key: &Path) -> ServerConfig {
+    config_from_path(cert, key)
+}
+
 /// A TlsStream that lazily does ths TLS handshake.
 #[derive(Debug)]
 pub(crate) struct TlsStream<T> {


### PR DESCRIPTION
Added more flexible tls support.

- **Features**:
  - Configurable tls support

- **Changes**
  - Expose `tls` module
  - Add `tls::config`, `tls::config_from_path`, `tls::config_from_der_data`.
  - Add `tls2` method on `warp::Server` to take `ServerConfig` instead of path only
    `tls` variant.
  - `tls::configure` has been deprecated
  - `tls` method of `warp::Server` has been deprecated.

This is relatively small but breaking change (eventually - currently non-breaking with deprecation notes) for tls.  So, took the liberty to document it and do a version bump. If that isn't acceptable, please let me know and I'll look at how to restructure this.