### PR TITLE
impls ReplySealed for Cow<'static, str>.

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -357,6 +357,8 @@ impl<T: Reply> ReplySealed for WithHeader<T> {
 
 // Seal the `Reply` trait and the `Reply_` wrapper type for now.
 mod sealed {
+    use std::borrow::Cow;
+
     use hyper::Body;
 
     use generic::{Either, One};
@@ -478,6 +480,16 @@ mod sealed {
                 )
                 .body(Body::from(self))
                 .unwrap()
+        }
+    }
+
+    impl ReplySealed for Cow<'static, str> {
+        #[inline]
+        fn into_response(self) -> Response {
+            match self {
+                Cow::Borrowed(s) => s.into_response(),
+                Cow::Owned(s) => s.into_response()
+            }
         }
     }
 


### PR DESCRIPTION
Hi, thanks for the great warp lib!
I think it is useful if the enum Cow which represents string implements Reply(Sealed).

In my case, it is especially nice when using the with_status method to make a impl Reply like a WithStatus.
If the Cow implements Reply, Error(assume enum) which has some static str, String, or Cow, and which is underlying a Rejection can provide first argument of the method without unnecessary allocation.

I implemented it by using existing impl for static str and String.