### PR TITLE
Update rustls to avoid conflict with reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.5.3"
 tokio = "0.1.11"
 tokio-io = "0.1"
-rustls = { version = "0.14", optional = true }
+rustls = { version = "0.15", optional = true }
 tokio-threadpool = "0.1.7"
 # tls is enabled by default, we don't want that yet
 tungstenite = { default-features = false, version = "0.6" }


### PR DESCRIPTION
This change solves the following dependency conflict when using reqwest `0.9` with warp `0.1`.

```
error: failed to select a version for `ring`.
    ... required by package `rustls v0.14.0`
    ... which is depended on by `warp v0.1.14`
    ... which is depended on by `my-crate v0.1.0 (/home/joshua/Projects/my-crate)`
versions that meet the requirements `^0.13.2` are: 0.13.5

the package `ring` links to the native library `ring-asm`, but it conflicts with a previous package which links to `ring-asm` as well:
package `ring v0.14.6`
    ... which is depended on by `rustls v0.15.1`
    ... which is depended on by `tokio-rustls v0.9.1`
    ... which is depended on by `hyper-rustls v0.16.1`
    ... which is depended on by `reqwest v0.9.12`
    ... which is depended on by `my-crate v0.1.0 (/home/joshua/Projects/my-crate)`
```