### PR TITLE
Add keep_alive

### DIFF
--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -517,6 +517,9 @@ where
 /// as shown below.
 ///
 /// ```
+/// extern crate pretty_env_logger;
+/// extern crate tokio;
+/// extern crate warp;
 /// use std::time::Duration;
 /// use tokio::{clock::now, timer::Interval};
 /// use warp::{Filter, Stream};
@@ -536,7 +539,6 @@ where
 ///                           .with_interval(Duration::from_secs(5))
 ///                           .with_text("thump".to_string()))
 ///         });
-///     warp::serve(routes).run(([127, 0, 0, 1], 3030));
 /// }
 /// ```
 ///


### PR DESCRIPTION
This pull request adds `keep_alive`, which is an updated version of `keep` that
has been modified to use the builder pattern (as discussed in #204).  This removes the need to pass a `None` to get the default interval of 15 seconds and allows users to customize the text of the keep-alive comment.