### PR TITLE
Add warp::sse::keep_alive() to replace keep()

### DIFF
--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -62,7 +62,7 @@ fn main() {
             .map(|sse: warp::sse::Sse, users| {
                 // reply using server-sent events
                 let stream = user_connected(users);
-                sse.reply(warp::sse::keep(stream, None))
+                sse.reply(warp::sse::keep_alive().stream(stream))
             });
 
     // GET / -> index html


### PR DESCRIPTION
The keep_alive() function returns a builder to allow customizing the
interval and content of keep-alive SSE messages. Adjusts the work in #206.

Closes #206 
Closes #204 