### PR TITLE
Fix doc link to reject module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,6 @@ extern crate bytes;
 #[macro_use]
 extern crate futures;
 extern crate headers;
-#[doc(hidden)]
 pub extern crate http;
 extern crate hyper;
 #[macro_use]

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -127,7 +127,7 @@ pub(crate) fn known(err: impl Into<Cause>) -> Rejection {
 
 /// Rejection of a request by a [`Filter`](::Filter).
 ///
-/// See the [`reject`](reject) documentation for more.
+/// See the [`reject`](index.html) documentation for more.
 pub struct Rejection {
     reason: Reason,
 }


### PR DESCRIPTION
Also expose re-export of `http` crate in the docs. Rationale: http crate is fundemantal for using the APIs of warp. Examples are using it as re-export, therefore I think it should be marked as such in the docs. It also helps not to confuse users of warp to add `http` to their Cargo.toml.