### PR TITLE
Update crate to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/warp"
 repository = "https://github.com/seanmonstar/warp"
 categories = ["web-programming::http-server"]
 keywords = ["warp", "server", "http", "hyper"]
+edition = "2018"
 
 [dependencies]
 bytes = "0.4.8"

--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -37,7 +37,7 @@ impl StdError for Error {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         None
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use hyper::Error as HyperError;
 use tungstenite::Error as WsError;
 
-use never::Never;
+use crate::never::Never;
 
 /// Errors that can happen inside warp.
 pub struct Error(Box<Kind>);

--- a/src/filter/and.rs
+++ b/src/filter/and.rs
@@ -3,7 +3,7 @@ use std::mem;
 use futures::{Async, Future, Poll};
 
 use super::{Combine, Filter, FilterBase, HList, Tuple};
-use reject::CombineRejection;
+use crate::reject::CombineRejection;
 
 #[derive(Clone, Copy, Debug)]
 pub struct And<T, U> {

--- a/src/filter/and_then.rs
+++ b/src/filter/and_then.rs
@@ -3,7 +3,7 @@ use std::mem;
 use futures::{Async, Future, IntoFuture, Poll};
 
 use super::{Filter, FilterBase, Func};
-use reject::CombineRejection;
+use crate::reject::CombineRejection;
 
 #[derive(Clone, Copy, Debug)]
 pub struct AndThen<T, F> {

--- a/src/filter/boxed.rs
+++ b/src/filter/boxed.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use futures::Future;
 
 use super::{Filter, FilterBase, Tuple};
-use reject::Rejection;
+use crate::reject::Rejection;
 
 /// A type representing a boxed `Filter` trait object.
 ///

--- a/src/filter/map_err.rs
+++ b/src/filter/map_err.rs
@@ -1,7 +1,7 @@
 use futures::{Future, Poll};
 
 use super::{Filter, FilterBase};
-use reject::Reject;
+use crate::reject::Reject;
 
 #[derive(Clone, Copy, Debug)]
 pub struct MapErr<T, F> {

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -13,9 +13,9 @@ mod wrap;
 
 use futures::{future, Future, IntoFuture};
 
-pub(crate) use generic::{one, Combine, Either, Func, HList, One, Tuple};
-use reject::{CombineRejection, Reject, Rejection};
-use route::{self, Route};
+pub(crate) use crate::generic::{one, Combine, Either, Func, HList, One, Tuple};
+use crate::reject::{CombineRejection, Reject, Rejection};
+use crate::route::{self, Route};
 
 pub(crate) use self::and::And;
 use self::and_then::AndThen;
@@ -65,7 +65,7 @@ pub trait FilterBase {
 /// ```
 pub fn __warp_filter_compilefail_doctest() {
     // Duplicate code to make sure the code is otherwise valid.
-    let _ = ::any().filter();
+    let _ = crate::any().filter();
 }
 
 /// Composable request filters.

--- a/src/filter/or.rs
+++ b/src/filter/or.rs
@@ -3,9 +3,9 @@ use std::mem;
 use futures::{Async, Future, Poll};
 
 use super::{Filter, FilterBase};
-use generic::Either;
-use reject::CombineRejection;
-use route;
+use crate::generic::Either;
+use crate::reject::CombineRejection;
+use crate::route;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Or<T, U> {

--- a/src/filter/or_else.rs
+++ b/src/filter/or_else.rs
@@ -3,7 +3,7 @@ use std::mem;
 use futures::{Async, Future, IntoFuture, Poll};
 
 use super::{Filter, FilterBase, Func};
-use route;
+use crate::route;
 
 #[derive(Clone, Copy, Debug)]
 pub struct OrElse<T, F> {

--- a/src/filter/recover.rs
+++ b/src/filter/recover.rs
@@ -3,8 +3,8 @@ use std::mem;
 use futures::{Async, Future, IntoFuture, Poll};
 
 use super::{Filter, FilterBase, Func};
-use generic::Either;
-use route;
+use crate::generic::Either;
+use crate::route;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Recover<T, F> {

--- a/src/filter/service.rs
+++ b/src/filter/service.rs
@@ -2,11 +2,11 @@ use std::net::SocketAddr;
 
 use futures::{Future, Poll};
 
-use reject::Reject;
-use reply::Reply;
-use route::{self, Route};
-use server::{IntoWarpService, WarpService};
-use {Filter, Request};
+use crate::reject::Reject;
+use crate::reply::Reply;
+use crate::route::{self, Route};
+use crate::server::{IntoWarpService, WarpService};
+use crate::{Filter, Request};
 
 #[derive(Copy, Clone, Debug)]
 pub struct FilteredService<F> {

--- a/src/filters/addr.rs
+++ b/src/filters/addr.rs
@@ -2,8 +2,8 @@
 
 use std::net::SocketAddr;
 
-use filter::{filter_fn_one, Filter};
-use never::Never;
+use crate::filter::{filter_fn_one, Filter};
+use crate::never::Never;
 
 /// Creates a `Filter` to get the remote address of the connection.
 ///

--- a/src/filters/any.rs
+++ b/src/filters/any.rs
@@ -2,8 +2,8 @@
 
 use futures::{Future, Poll};
 
-use filter::{Filter, FilterBase};
-use never::Never;
+use crate::filter::{Filter, FilterBase};
+use crate::never::Never;
 
 /// A filter that matches any route.
 ///

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -16,8 +16,8 @@ use serde::de::DeserializeOwned;
 use serde_json;
 use serde_urlencoded;
 
-use filter::{filter_fn, filter_fn_one, Filter, FilterBase};
-use reject::{self, Rejection};
+use crate::filter::{filter_fn, filter_fn_one, Filter, FilterBase};
+use crate::reject::{self, Rejection};
 
 // Extracts the `Body` Stream from the route.
 //
@@ -46,7 +46,7 @@ pub(crate) fn body() -> impl Filter<Extract = (Body,), Error = Rejection> + Copy
 ///     .and(warp::body::concat());
 /// ```
 pub fn content_length_limit(limit: u64) -> impl Filter<Extract = (), Error = Rejection> + Copy {
-    ::filters::header::header2()
+    crate::filters::header::header2()
         .map_err(|_| {
             debug!("content-length missing");
             reject::length_required()
@@ -269,13 +269,13 @@ pub struct BodyStream {
 
 impl Stream for BodyStream {
     type Item = StreamBuf;
-    type Error = ::Error;
+    type Error = crate::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         let opt_item = try_ready!(self
             .body
             .poll()
-            .map_err(|e| ::Error::from(::error::Kind::Hyper(e))));
+            .map_err(|e| crate::Error::from(crate::error::Kind::Hyper(e))));
 
         Ok(opt_item.map(|chunk| StreamBuf { chunk }).into())
     }

--- a/src/filters/cookie.rs
+++ b/src/filters/cookie.rs
@@ -3,9 +3,9 @@
 use headers::Cookie;
 
 use super::header;
-use filter::{filter_fn_one, Filter, One};
-use never::Never;
-use reject::Rejection;
+use crate::filter::{filter_fn_one, Filter, One};
+use crate::never::Never;
+use crate::reject::Rejection;
 
 /// Creates a `Filter` that requires a cookie by name.
 ///
@@ -15,7 +15,7 @@ pub fn cookie(name: &'static str) -> impl Filter<Extract = One<String>, Error = 
         cookie
             .get(name)
             .map(String::from)
-            .ok_or_else(|| ::reject::known(MissingCookie(name)))
+            .ok_or_else(|| crate::reject::known(MissingCookie(name)))
     })
 }
 

--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -10,9 +10,9 @@ use http::{
     HttpTryFrom,
 };
 
-use filter::{Filter, WrapSealed};
-use reject::{CombineRejection, Rejection};
-use reply::Reply;
+use crate::filter::{Filter, WrapSealed};
+use crate::reject::{CombineRejection, Rejection};
+use crate::reply::Reply;
 
 use self::internal::{CorsFilter, IntoOrigin, Seconds};
 
@@ -408,10 +408,10 @@ mod internal {
     use http::header;
 
     use super::{Configured, CorsForbidden, Validated};
-    use filter::{Filter, FilterBase, One};
-    use generic::Either;
-    use reject::{CombineRejection, Rejection};
-    use route;
+    use crate::filter::{Filter, FilterBase, One};
+    use crate::generic::Either;
+    use crate::reject::{CombineRejection, Rejection};
+    use crate::route;
 
     #[derive(Debug)]
     pub struct CorsFilter<F> {
@@ -454,7 +454,7 @@ mod internal {
                     wrapped: None,
                 }),
                 Err(err) => {
-                    let rejection = ::reject::known(CorsForbidden { kind: err });
+                    let rejection = crate::reject::known(CorsForbidden { kind: err });
                     future::Either::A(future::err(rejection.into()))
                 }
             }
@@ -467,9 +467,9 @@ mod internal {
         origin: header::HeaderValue,
     }
 
-    impl ::reply::ReplySealed for Preflight {
-        fn into_response(self) -> ::reply::Response {
-            let mut res = ::reply::Response::default();
+    impl crate::reply::ReplySealed for Preflight {
+        fn into_response(self) -> crate::reply::Response {
+            let mut res = crate::reply::Response::default();
             self.config.append_preflight_headers(res.headers_mut());
             res.headers_mut()
                 .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, self.origin);
@@ -484,11 +484,11 @@ mod internal {
         origin: header::HeaderValue,
     }
 
-    impl<R> ::reply::ReplySealed for Wrapped<R>
+    impl<R> crate::reply::ReplySealed for Wrapped<R>
     where
-        R: ::reply::ReplySealed,
+        R: crate::reply::ReplySealed,
     {
-        fn into_response(self) -> ::reply::Response {
+        fn into_response(self) -> crate::reply::Response {
             let mut res = self.inner.into_response();
             self.config.append_common_headers(res.headers_mut());
             res.headers_mut()

--- a/src/filters/ext.rs
+++ b/src/filters/ext.rs
@@ -1,7 +1,7 @@
 //! Request Extensions
 
-use filter::{filter_fn_one, Filter};
-use reject::{self, Rejection};
+use crate::filter::{filter_fn_one, Filter};
+use crate::reject::{self, Rejection};
 
 /// Get a previously set extension of the current route.
 ///
@@ -26,7 +26,7 @@ pub fn get<T: Clone + Send + Sync + 'static>(
 ///
 /// This function panics if not called within the context of a `Filter`.
 pub fn set<T: Send + Sync + 'static>(val: T) {
-    ::route::with(move |route| {
+    crate::route::with(move |route| {
         route.extensions_mut().insert(val);
     });
 }

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -21,10 +21,10 @@ use tokio::io::AsyncRead;
 use tokio_threadpool;
 use urlencoding::decode;
 
-use filter::{Filter, FilterClone, One};
-use never::Never;
-use reject::{self, Rejection};
-use reply::{ReplySealed, Response};
+use crate::filter::{Filter, FilterClone, One};
+use crate::never::Never;
+use crate::reject::{self, Rejection};
+use crate::reply::{ReplySealed, Response};
 
 /// Creates a `Filter` that serves a File at the `path`.
 ///
@@ -50,7 +50,7 @@ use reply::{ReplySealed, Response};
 /// if starting a runtime manually.
 pub fn file(path: impl Into<PathBuf>) -> impl FilterClone<Extract = One<File>, Error = Rejection> {
     let path = Arc::new(path.into());
-    ::any()
+    crate::any()
         .map(move || {
             trace!("file: {:?}", path);
             ArcPath(path.clone())
@@ -89,7 +89,7 @@ pub fn file(path: impl Into<PathBuf>) -> impl FilterClone<Extract = One<File>, E
 /// if starting a runtime manually.
 pub fn dir(path: impl Into<PathBuf>) -> impl FilterClone<Extract = One<File>, Error = Rejection> {
     let base = Arc::new(path.into());
-    ::get2()
+    crate::get2()
         .and(path_from_tail(base))
         .and(conditionals())
         .and_then(file_reply)
@@ -98,8 +98,8 @@ pub fn dir(path: impl Into<PathBuf>) -> impl FilterClone<Extract = One<File>, Er
 fn path_from_tail(
     base: Arc<PathBuf>,
 ) -> impl FilterClone<Extract = One<ArcPath>, Error = Rejection> {
-    ::path::tail()
-        .and_then(move |tail: ::path::Tail| {
+    crate::path::tail()
+        .and_then(move |tail: crate::path::Tail| {
             let mut buf = PathBuf::from(base.as_ref());
             let p = match decode(tail.as_str()) {
                 Ok(p) => p,
@@ -213,10 +213,10 @@ impl Conditionals {
 }
 
 fn conditionals() -> impl Filter<Extract = One<Conditionals>, Error = Never> + Copy {
-    ::header::optional2()
-        .and(::header::optional2())
-        .and(::header::optional2())
-        .and(::header::optional2())
+    crate::header::optional2()
+        .and(crate::header::optional2())
+        .and(crate::header::optional2())
+        .and(crate::header::optional2())
         .map(
             |if_modified_since, if_unmodified_since, if_range, range| Conditionals {
                 if_modified_since,

--- a/src/filters/header.rs
+++ b/src/filters/header.rs
@@ -9,9 +9,9 @@ use std::str::FromStr;
 use headers::{Header, HeaderMapExt};
 use http::HeaderMap;
 
-use filter::{filter_fn, filter_fn_one, Filter, One};
-use never::Never;
-use reject::{self, Rejection};
+use crate::filter::{filter_fn, filter_fn_one, Filter, One};
+use crate::never::Never;
+use crate::reject::{self, Rejection};
 
 /// Create a `Filter` that tries to parse the specified header.
 ///

--- a/src/filters/log.rs
+++ b/src/filters/log.rs
@@ -7,10 +7,10 @@ use std::time::{Duration, Instant};
 use http::{self, header, StatusCode};
 use tokio::clock;
 
-use filter::{Filter, WrapSealed};
-use reject::Reject;
-use reply::Reply;
-use route::Route;
+use crate::filter::{Filter, WrapSealed};
+use crate::reject::Reject;
+use crate::reply::Reply;
+use crate::route::Route;
 
 use self::internal::WithLog;
 
@@ -183,10 +183,10 @@ mod internal {
     use futures::{Async, Future, Poll};
 
     use super::{Info, Log};
-    use filter::{Filter, FilterBase};
-    use reject::Reject;
-    use reply::{Reply, ReplySealed, Response};
-    use route;
+    use crate::filter::{Filter, FilterBase};
+    use crate::reject::Reject;
+    use crate::reply::{Reply, ReplySealed, Response};
+    use crate::route;
 
     #[allow(missing_debug_implementations)]
     pub struct Logged(pub(super) Response);

--- a/src/filters/method.rs
+++ b/src/filters/method.rs
@@ -8,9 +8,9 @@
 //! a request, and just extracts the method to be used in your filter chains.
 use http::Method;
 
-use filter::{filter_fn, filter_fn_one, And, Filter, One};
-use never::Never;
-use reject::{CombineRejection, Rejection};
+use crate::filter::{filter_fn, filter_fn_one, And, Filter, One};
+use crate::never::Never;
+use crate::reject::{CombineRejection, Rejection};
 
 pub use self::v2::{
     delete as delete2, get as get2, head, options, patch, post as post2, put as put2,
@@ -91,7 +91,7 @@ where
         if route.method() == method {
             Ok(())
         } else {
-            Err(::reject::method_not_allowed())
+            Err(crate::reject::method_not_allowed())
         }
     })
 }
@@ -104,8 +104,8 @@ pub mod v2 {
     //! `405 Method Not Allowed`.
     use http::Method;
 
-    use filter::Filter;
-    use reject::Rejection;
+    use crate::filter::Filter;
+    use crate::reject::Rejection;
 
     use super::method_is;
 

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -19,4 +19,4 @@ pub mod reply;
 pub mod sse;
 pub mod ws;
 
-pub use filter::BoxedFilter;
+pub use crate::filter::BoxedFilter;

--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -131,10 +131,10 @@ use std::str::FromStr;
 
 use http::uri::PathAndQuery;
 
-use filter::{filter_fn, one, Filter, One, Tuple};
-use never::Never;
-use reject::{self, Rejection};
-use route::Route;
+use crate::filter::{filter_fn, one, Filter, One, Tuple};
+use crate::never::Never;
+use crate::reject::{self, Rejection};
+use crate::route::Route;
 
 /// Create an exact match path segment `Filter`.
 ///
@@ -248,7 +248,7 @@ pub fn param<T: FromStr + Send>() -> impl Filter<Extract = One<T>, Error = Rejec
 pub fn param2<T>() -> impl Filter<Extract = One<T>, Error = Rejection> + Copy
 where
     T: FromStr + Send,
-    T::Err: Into<::reject::Cause>,
+    T::Err: Into<crate::reject::Cause>,
 {
     segment(|seg| {
         trace!("param?: {:?}", seg);

--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -3,8 +3,8 @@
 use serde::de::DeserializeOwned;
 use serde_urlencoded;
 
-use filter::{filter_fn_one, Filter, One};
-use reject::{self, Rejection};
+use crate::filter::{filter_fn_one, Filter, One};
+use crate::reject::{self, Rejection};
 
 /// Creates a `Filter` that decodes query parameters to the type `T`.
 ///

--- a/src/filters/reply.rs
+++ b/src/filters/reply.rs
@@ -25,8 +25,8 @@ use http::header::{HeaderMap, HeaderName, HeaderValue};
 use http::HttpTryFrom;
 
 use self::sealed::{WithDefaultHeader_, WithHeader_, WithHeaders_};
-use filter::{Filter, Map, WrapSealed};
-use reply::Reply;
+use crate::filter::{Filter, Map, WrapSealed};
+use crate::reply::Reply;
 
 /// Wrap a [`Filter`](::Filter) that adds a header to the reply.
 ///
@@ -191,8 +191,8 @@ where
 
 mod sealed {
     use super::{WithDefaultHeader, WithHeader, WithHeaders};
-    use generic::{Func, One};
-    use reply::{Reply, Reply_};
+    use crate::generic::{Func, One};
+    use crate::reply::{Reply, Reply_};
 
     #[derive(Clone)]
     #[allow(missing_debug_implementations)]

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -479,7 +479,10 @@ impl KeepAlive {
     /// Wrap an event stream with keep-alive functionality.
     ///
     /// See [`keep_alive`](super::keep_alive) for more.
-    pub fn stream<S>(self, event_stream: S) -> impl Stream<
+    pub fn stream<S>(
+        self,
+        event_stream: S,
+    ) -> impl Stream<
         Item = impl ServerSentEvent + Send + 'static,
         Error = impl StdError + Send + Sync + 'static,
     > + Send + 'static
@@ -505,7 +508,6 @@ struct SseKeepAlive<S> {
     max_interval: Duration,
     alive_timer: Delay,
 }
-
 
 #[doc(hidden)]
 #[deprecated(note = "use warp::see:keep_alive() instead")]

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -52,9 +52,9 @@ use self::sealed::{
     BoxedServerSentEvent, EitherServerSentEvent, SseError, SseField, SseFormat, SseWrapper,
 };
 use super::{header, header::MissingHeader};
-use filter::One;
-use reply::{ReplySealed, Response};
-use {Filter, Rejection, Reply};
+use crate::filter::One;
+use crate::reply::{ReplySealed, Response};
+use crate::{Filter, Rejection, Reply};
 
 /// Server-sent event message
 pub trait ServerSentEvent: SseFormat + Sized + Send + 'static {
@@ -318,7 +318,7 @@ where
 /// - Header `content-type: text/event-stream`
 /// - Header `cache-control: no-cache`.
 pub fn sse() -> impl Filter<Extract = One<Sse>, Error = Rejection> + Copy {
-    ::get2()
+    crate::get2()
         .and(
             header::exact_ignore_case("connection", "keep-alive").or_else(
                 |rejection: Rejection| {

--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -11,10 +11,10 @@ use http;
 use tungstenite::protocol::{self, WebSocketConfig};
 
 use super::{body, header};
-use error::Kind;
-use filter::{Filter, FilterClone, One};
-use reject::Rejection;
-use reply::{Reply, ReplySealed, Response};
+use crate::error::Kind;
+use crate::filter::{Filter, FilterClone, One};
+use crate::reject::Rejection;
+use crate::reply::{Reply, ReplySealed, Response};
 
 #[doc(hidden)]
 #[deprecated(note = "will be replaced by ws2")]
@@ -59,12 +59,12 @@ pub fn ws2() -> impl Filter<Extract = One<Ws2>, Error = Rejection> + Copy {
             if conn.contains("upgrade") {
                 Ok(())
             } else {
-                Err(::reject::bad_request())
+                Err(crate::reject::bad_request())
             }
         })
         .untuple_one();
 
-    ::get2()
+    crate::get2()
         .and(connection_has_upgrade)
         .and(header::exact_ignore_case("upgrade", "websocket"))
         .and(header::exact("sec-websocket-version", "13"))
@@ -225,14 +225,14 @@ impl WebSocket {
     }
 
     /// Gracefully close this websocket.
-    pub fn close(mut self) -> impl Future<Item = (), Error = ::Error> {
+    pub fn close(mut self) -> impl Future<Item = (), Error = crate::Error> {
         future::poll_fn(move || Sink::close(&mut self))
     }
 }
 
 impl Stream for WebSocket {
     type Item = Message;
-    type Error = ::Error;
+    type Error = crate::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         loop {
@@ -267,7 +267,7 @@ impl Stream for WebSocket {
 
 impl Sink for WebSocket {
     type SinkItem = Message;
-    type SinkError = ::Error;
+    type SinkError = crate::Error;
 
     fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
         match item.inner {

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -93,14 +93,14 @@ where
     }
 }
 
-impl<F, R> Func<::Rejection> for F
+impl<F, R> Func<crate::Rejection> for F
 where
-    F: Fn(::Rejection) -> R,
+    F: Fn(crate::Rejection) -> R,
 {
     type Output = R;
 
     #[inline]
-    fn call(&self, arg: ::Rejection) -> Self::Output {
+    fn call(&self, arg: crate::Rejection) -> Self::Output {
         (*self)(arg)
     }
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -6,7 +6,7 @@
 use http::{header, StatusCode};
 
 use self::sealed::AsLocation;
-use reply::{self, Reply};
+use crate::reply::{self, Reply};
 
 /// A simple `301` redirect to a different location.
 ///

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -39,7 +39,7 @@ use hyper::Body;
 use serde;
 use serde_json;
 
-use never::Never;
+use crate::never::Never;
 
 pub(crate) use self::sealed::{CombineRejection, Reject};
 
@@ -231,7 +231,7 @@ impl Rejection {
 
     #[doc(hidden)]
     #[deprecated(note = "Use warp::reply::json and warp::reply::with_status instead.")]
-    pub fn json(&self) -> ::reply::Response {
+    pub fn json(&self) -> crate::reply::Response {
         let code = self.status();
         let mut res = http::Response::default();
         *res.status_mut() = code;
@@ -289,7 +289,7 @@ impl Reject for Never {
         match *self {}
     }
 
-    fn into_response(&self) -> ::reply::Response {
+    fn into_response(&self) -> crate::reply::Response {
         match *self {}
     }
 
@@ -306,7 +306,7 @@ impl Reject for Rejection {
         }
     }
 
-    fn into_response(&self) -> ::reply::Response {
+    fn into_response(&self) -> crate::reply::Response {
         match self.reason {
             Reason::NotFound => {
                 let mut res = http::Response::default();
@@ -368,13 +368,13 @@ impl Rejections {
             Rejections::Known(ref e) => {
                 if e.is::<MethodNotAllowed>() {
                     StatusCode::METHOD_NOT_ALLOWED
-                } else if e.is::<::header::InvalidHeader>() {
+                } else if e.is::<crate::header::InvalidHeader>() {
                     StatusCode::BAD_REQUEST
-                } else if e.is::<::header::MissingHeader>() {
+                } else if e.is::<crate::header::MissingHeader>() {
                     StatusCode::BAD_REQUEST
-                } else if e.is::<::cookie::MissingCookie>() {
+                } else if e.is::<crate::cookie::MissingCookie>() {
                     StatusCode::BAD_REQUEST
-                } else if e.is::<::query::InvalidQuery>() {
+                } else if e.is::<crate::query::InvalidQuery>() {
                     StatusCode::BAD_REQUEST
                 } else if e.is::<LengthRequired>() {
                     StatusCode::LENGTH_REQUIRED
@@ -382,21 +382,21 @@ impl Rejections {
                     StatusCode::PAYLOAD_TOO_LARGE
                 } else if e.is::<UnsupportedMediaType>() {
                     StatusCode::UNSUPPORTED_MEDIA_TYPE
-                } else if e.is::<::body::BodyReadError>() {
+                } else if e.is::<crate::body::BodyReadError>() {
                     StatusCode::BAD_REQUEST
-                } else if e.is::<::body::BodyDeserializeError>() {
+                } else if e.is::<crate::body::BodyDeserializeError>() {
                     StatusCode::BAD_REQUEST
-                } else if e.is::<::cors::CorsForbidden>() {
+                } else if e.is::<crate::cors::CorsForbidden>() {
                     StatusCode::FORBIDDEN
-                } else if e.is::<::ext::MissingExtension>() {
+                } else if e.is::<crate::ext::MissingExtension>() {
                     StatusCode::INTERNAL_SERVER_ERROR
-                } else if e.is::<::reply::ReplyHttpError>() {
+                } else if e.is::<crate::reply::ReplyHttpError>() {
                     StatusCode::INTERNAL_SERVER_ERROR
-                } else if e.is::<::reply::ReplyJsonError>() {
+                } else if e.is::<crate::reply::ReplyJsonError>() {
                     StatusCode::INTERNAL_SERVER_ERROR
-                } else if e.is::<::body::BodyConsumedMultipleTimes>() {
+                } else if e.is::<crate::body::BodyConsumedMultipleTimes>() {
                     StatusCode::INTERNAL_SERVER_ERROR
-                } else if e.is::<::fs::FsNeedsTokioThreadpool>() {
+                } else if e.is::<crate::fs::FsNeedsTokioThreadpool>() {
                     StatusCode::INTERNAL_SERVER_ERROR
                 } else {
                     unreachable!("unexpected 'Known' rejection: {:?}", e);
@@ -409,7 +409,7 @@ impl Rejections {
         }
     }
 
-    fn into_response(&self) -> ::reply::Response {
+    fn into_response(&self) -> crate::reply::Response {
         match *self {
             Rejections::Known(ref e) => {
                 let mut res = http::Response::new(Body::from(e.to_string()));
@@ -421,7 +421,7 @@ impl Rejections {
                 res
             }
             Rejections::KnownStatus(ref s) => {
-                use reply::ReplySealed;
+                use crate::reply::ReplySealed;
                 s.into_response()
             }
             Rejections::With(ref rej, ref e) => {
@@ -572,12 +572,12 @@ trait Typed: StdError + 'static {
 mod sealed {
     use super::{Cause, Reason, Rejection, Rejections};
     use http::StatusCode;
-    use never::Never;
+    use crate::never::Never;
     use std::fmt;
 
     pub trait Reject: fmt::Debug + Send + Sync {
         fn status(&self) -> StatusCode;
-        fn into_response(&self) -> ::reply::Response;
+        fn into_response(&self) -> crate::reply::Response;
         fn cause(&self) -> Option<&Cause> {
             None
         }
@@ -783,7 +783,7 @@ mod tests {
         assert_eq!(expected, response_body_string(resp))
     }
 
-    fn response_body_string(resp: ::reply::Response) -> String {
+    fn response_body_string(resp: crate::reply::Response) -> String {
         use futures::{Async, Future, Stream};
 
         let (_, body) = resp.into_parts();

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -571,8 +571,8 @@ trait Typed: StdError + 'static {
 
 mod sealed {
     use super::{Cause, Reason, Rejection, Rejections};
-    use http::StatusCode;
     use crate::never::Never;
+    use http::StatusCode;
     use std::fmt;
 
     pub trait Reject: fmt::Debug + Send + Sync {

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -42,11 +42,11 @@ use hyper::Body;
 use serde::Serialize;
 use serde_json;
 
-use reject::Reject;
+use crate::reject::Reject;
 // This re-export just looks weird in docs...
 pub(crate) use self::sealed::{ReplyHttpError, ReplySealed, Reply_, Response};
 #[doc(hidden)]
-pub use filters::reply as with;
+pub use crate::filters::reply as with;
 
 /// Returns an empty `Reply` with status code `200 OK`.
 ///
@@ -119,7 +119,7 @@ impl ReplySealed for Json {
                     .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
                 res
             }
-            Err(()) => ::reject::known(ReplyJsonError).into_response(),
+            Err(()) => crate::reject::known(ReplyJsonError).into_response(),
         }
     }
 }
@@ -361,8 +361,8 @@ mod sealed {
 
     use hyper::Body;
 
-    use generic::{Either, One};
-    use reject::Reject;
+    use crate::generic::{Either, One};
+    use crate::reject::Reject;
 
     use super::{HeaderValue, Reply, CONTENT_TYPE};
 
@@ -380,7 +380,7 @@ mod sealed {
     /// ```
     pub fn __warp_replysealed_compilefail_doctest() {
         // Duplicate code to make sure the code is otherwise valid.
-        let _ = ::reply().into_response();
+        let _ = crate::reply().into_response();
     }
 
     // An opaque type to return `impl Reply` from trait methods.
@@ -423,7 +423,7 @@ mod sealed {
                 Ok(t) => t.into_response(),
                 Err(e) => {
                     error!("reply error: {:?}", e);
-                    ::reject::known(ReplyHttpError(e)).into_response()
+                    crate::reject::known(ReplyHttpError(e)).into_response()
                 }
             }
         }
@@ -530,7 +530,7 @@ mod sealed {
         }
     }
 
-    impl ReplySealed for ::never::Never {
+    impl ReplySealed for crate::never::Never {
         #[inline(always)]
         fn into_response(self) -> Response {
             match self {}

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -488,7 +488,7 @@ mod sealed {
         fn into_response(self) -> Response {
             match self {
                 Cow::Borrowed(s) => s.into_response(),
-                Cow::Owned(s) => s.into_response()
+                Cow::Owned(s) => s.into_response(),
             }
         }
     }

--- a/src/route.rs
+++ b/src/route.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 use http;
 use hyper::Body;
 
-use Request;
+use crate::Request;
 
 scoped_thread_local!(static ROUTE: RefCell<Route>);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,11 +9,11 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{rt, Server as HyperServer};
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use never::Never;
-use reject::Reject;
-use reply::{Reply, ReplySealed};
-use transport::Transport;
-use Request;
+use crate::never::Never;
+use crate::reject::Reject;
+use crate::reply::{Reply, ReplySealed};
+use crate::transport::Transport;
+use crate::Request;
 
 /// Create a `Server` with the provided service.
 pub fn serve<S>(service: S) -> Server<S>
@@ -121,7 +121,7 @@ where
         I::Item: AsyncRead + AsyncWrite + Send + 'static,
         I::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
-        self.run_incoming2(incoming.map(::transport::LiftIo));
+        self.run_incoming2(incoming.map(crate::transport::LiftIo));
     }
 
     fn run_incoming2<I>(self, incoming: I)
@@ -215,7 +215,7 @@ where
         I::Item: AsyncRead + AsyncWrite + Send + 'static,
         I::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
-        let incoming = incoming.map(::transport::LiftIo);
+        let incoming = incoming.map(crate::transport::LiftIo);
         self.serve_incoming2(incoming)
     }
 
@@ -354,7 +354,7 @@ where
     F::Item: Reply,
     F::Error: Reject,
 {
-    type Item = ::reply::Response;
+    type Item = crate::reply::Response;
     type Error = Never;
 
     #[inline]

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,6 +14,7 @@ use crate::reject::Reject;
 use crate::reply::{Reply, ReplySealed};
 use crate::transport::Transport;
 use crate::Request;
+use crate::tls as Tls;
 
 /// Create a `Server` with the provided service.
 pub fn serve<S>(service: S) -> Server<S>
@@ -85,7 +86,7 @@ macro_rules! bind_inner {
         let tls = Arc::new($this.tls);
         let incoming = incoming.map(move |sock| {
             let session = ::rustls::ServerSession::new(&tls);
-            ::tls::TlsStream::new(sock, session)
+            Tls::TlsStream::new(sock, session)
         });
         let srv = HyperServer::builder(incoming)
             .http1_pipeline_flush($this.server.pipeline)
@@ -246,7 +247,7 @@ where
     /// *This function requires the `"tls"` feature.*
     #[cfg(feature = "tls")]
     pub fn tls(self, cert: impl AsRef<Path>, key: impl AsRef<Path>) -> TlsServer<S> {
-        let tls = ::tls::configure(cert.as_ref(), key.as_ref());
+        let tls = Tls::configure(cert.as_ref(), key.as_ref());
 
         TlsServer { server: self, tls }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -99,11 +99,11 @@ use serde::Serialize;
 use serde_json;
 use tokio::runtime::{Builder as RtBuilder, Runtime};
 
-use filter::Filter;
-use reject::Reject;
-use reply::{Reply, ReplySealed};
-use route::{self, Route};
-use Request;
+use crate::filter::Filter;
+use crate::reject::Reject;
+use crate::reply::{Reply, ReplySealed};
+use crate::route::{self, Route};
+use crate::Request;
 
 use self::inner::OneOrTuple;
 
@@ -141,8 +141,8 @@ pub struct WsBuilder {
 
 /// A test client for Websocket filters.
 pub struct WsClient {
-    tx: mpsc::UnboundedSender<::ws::Message>,
-    rx: ::futures::stream::Wait<mpsc::UnboundedReceiver<Result<::ws::Message, ::Error>>>,
+    tx: mpsc::UnboundedSender<crate::ws::Message>,
+    rx: ::futures::stream::Wait<mpsc::UnboundedReceiver<Result<crate::ws::Message, crate::Error>>>,
 }
 
 /// An error from Websocket filter tests.
@@ -444,7 +444,7 @@ impl WsBuilder {
             .spawn(move || {
                 use tungstenite::protocol;
 
-                let (addr, srv) = ::serve(f).bind_ephemeral(([127, 0, 0, 1], 0));
+                let (addr, srv) = crate::serve(f).bind_ephemeral(([127, 0, 0, 1], 0));
 
                 let srv = srv.map_err(|err| panic!("server error: {:?}", err));
 
@@ -485,7 +485,7 @@ impl WsBuilder {
                     protocol::Role::Client,
                     Default::default(),
                 );
-                let (tx, rx) = ::ws::WebSocket::new(io).split();
+                let (tx, rx) = crate::ws::WebSocket::new(io).split();
                 let write = wr_rx
                     .map_err(|()| {
                         unreachable!("mpsc::Receiver doesn't error");
@@ -516,16 +516,16 @@ impl WsBuilder {
 impl WsClient {
     /// Send a "text" websocket message to the server.
     pub fn send_text(&mut self, text: impl Into<String>) {
-        self.send(::ws::Message::text(text));
+        self.send(crate::ws::Message::text(text));
     }
 
     /// Send a websocket message to the server.
-    pub fn send(&mut self, msg: ::ws::Message) {
+    pub fn send(&mut self, msg: crate::ws::Message) {
         self.tx.unbounded_send(msg).unwrap();
     }
 
     /// Receive a websocket message from the server.
-    pub fn recv(&mut self) -> Result<::filters::ws::Message, WsError> {
+    pub fn recv(&mut self) -> Result<crate::filters::ws::Message, WsError> {
         self.rx
             .next()
             .map(|unbounded_result| {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -7,7 +7,7 @@ use futures::Poll;
 use rustls::{self, ServerConfig, ServerSession, Session, Stream};
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use transport::Transport;
+use crate::transport::Transport;
 
 pub(crate) fn configure(cert: &Path, key: &Path) -> ServerConfig {
     let cert = {


### PR DESCRIPTION
Update crate for Rust 2018 using 'cargo fix --edition'
closes #220 