### PR TITLE
Expose more basic internal HTTP error types

### DIFF
--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -65,8 +65,17 @@ fn customize_error(err: Rejection) -> Result<impl Reply, Rejection> {
             message: msg,
         });
         Ok(warp::reply::with_status(json, code))
+    } else if let Some(_) = err.find_cause::<warp::reject::MethodNotAllowed>() {
+        // We can handle a specific error, here METHOD_NOT_ALLOWED,
+        // and render it however we want
+        let code = StatusCode::METHOD_NOT_ALLOWED;
+        let json = warp::reply::json(&ErrorMessage {
+            code: code.as_u16(),
+            message: "oops, you aren't allowed to use this method.".into(),
+        });
+        Ok(warp::reply::with_status(json, code))
     } else {
-        // Could be a NOT_FOUND, or METHOD_NOT_ALLOWED... here we just
+        // Could be a NOT_FOUND, or any other internal error... here we just
         // let warp use its default rendering.
         Err(err)
     }

--- a/src/filters/cookie.rs
+++ b/src/filters/cookie.rs
@@ -1,7 +1,5 @@
 //! Cookie Filters
 
-use std::error::Error as StdError;
-
 use headers::Cookie;
 
 use super::header;
@@ -17,7 +15,7 @@ pub fn cookie(name: &'static str) -> impl Filter<Extract = One<String>, Error = 
         cookie
             .get(name)
             .map(String::from)
-            .ok_or_else(|| ::reject::known(MissingCookie(name)))
+            .ok_or_else(|| ::reject::missing_cookie(name))
     })
 }
 
@@ -49,22 +47,4 @@ where
             .typed_get()
             .and_then(|cookie: Cookie| cookie.get(name).map(func)))
     })
-}
-
-// ===== Rejections =====
-
-/// Missing cookie
-#[derive(Debug)]
-pub struct MissingCookie(&'static str);
-
-impl ::std::fmt::Display for MissingCookie {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Missing request cookie '{}'", self.0)
-    }
-}
-
-impl StdError for MissingCookie {
-    fn description(&self) -> &str {
-        "Missing request cookie"
-    }
 }

--- a/src/filters/cookie.rs
+++ b/src/filters/cookie.rs
@@ -53,8 +53,9 @@ where
 
 // ===== Rejections =====
 
+/// Missing cookie
 #[derive(Debug)]
-pub(crate) struct MissingCookie(&'static str);
+pub struct MissingCookie(&'static str);
 
 impl ::std::fmt::Display for MissingCookie {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {

--- a/src/filters/header.rs
+++ b/src/filters/header.rs
@@ -5,7 +5,6 @@
 //! they don't extract any values. The `header` filter allows parsing
 //! a type from any header.
 use std::str::FromStr;
-use std::error::Error as StdError;
 
 use headers::{Header, HeaderMapExt};
 use http::HeaderMap;
@@ -41,13 +40,13 @@ pub fn header<T: FromStr + Send>(
         route
             .headers()
             .get(name)
-            .ok_or_else(|| reject::known(MissingHeader(name)))
+            .ok_or_else(|| reject::missing_header(name))
             .and_then(|value| {
                 value
                     .to_str()
-                    .map_err(|_| reject::known(InvalidHeader(name)))
+                    .map_err(|_| reject::invalid_header(name))
             })
-            .and_then(|s| T::from_str(s).map_err(|_| reject::known(InvalidHeader(name))))
+            .and_then(|s| T::from_str(s).map_err(|_| reject::invalid_header(name)))
     })
 }
 
@@ -58,7 +57,7 @@ pub(crate) fn header2<T: Header + Send>() -> impl Filter<Extract = One<T>, Error
         route
             .headers()
             .typed_get()
-            .ok_or_else(|| reject::known(InvalidHeader(T::name().as_str())))
+            .ok_or_else(|| reject::invalid_header(T::name().as_str()))
     })
 }
 
@@ -85,9 +84,9 @@ where
         let result = route.headers().get(name).map(|value| {
             value
                 .to_str()
-                .map_err(|_| reject::known(InvalidHeader(name)))?
+                .map_err(|_| reject::invalid_header(name))?
                 .parse::<T>()
-                .map_err(|_| reject::known(InvalidHeader(name)))
+                .map_err(|_| reject::invalid_header(name))
         });
 
         match result {
@@ -144,12 +143,12 @@ pub fn exact(
         route
             .headers()
             .get(name)
-            .ok_or_else(|| reject::known(MissingHeader(name)))
+            .ok_or_else(|| reject::missing_header(name))
             .and_then(|val| {
                 if val == value {
                     Ok(())
                 } else {
-                    Err(reject::known(InvalidHeader(name)))
+                    Err(reject::invalid_header(name))
                 }
             })
     })
@@ -175,12 +174,12 @@ pub fn exact_ignore_case(
         route
             .headers()
             .get(name)
-            .ok_or_else(|| reject::known(MissingHeader(name)))
+            .ok_or_else(|| reject::missing_header(name))
             .and_then(|val| {
                 if val.as_bytes().eq_ignore_ascii_case(value.as_bytes()) {
                     Ok(())
                 } else {
-                    Err(reject::known(InvalidHeader(name)))
+                    Err(reject::invalid_header(name))
                 }
             })
     })
@@ -200,38 +199,4 @@ pub fn exact_ignore_case(
 /// ```
 pub fn headers_cloned() -> impl Filter<Extract = One<HeaderMap>, Error = Never> + Copy {
     filter_fn_one(|route| Ok(route.headers().clone()))
-}
-
-// ===== Rejections =====
-
-/// Missing request header
-#[derive(Debug)]
-pub struct MissingHeader(&'static str);
-
-impl ::std::fmt::Display for MissingHeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Missing request header '{}'", self.0)
-    }
-}
-
-impl StdError for MissingHeader {
-    fn description(&self) -> &str {
-        "Missing request header"
-    }
-}
-
-/// Invalid request header
-#[derive(Debug)]
-pub struct InvalidHeader(&'static str);
-
-impl ::std::fmt::Display for InvalidHeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "Invalid request header '{}'", self.0)
-    }
-}
-
-impl StdError for InvalidHeader {
-    fn description(&self) -> &str {
-        "Invalid request header"
-    }
 }

--- a/src/filters/header.rs
+++ b/src/filters/header.rs
@@ -204,8 +204,9 @@ pub fn headers_cloned() -> impl Filter<Extract = One<HeaderMap>, Error = Never> 
 
 // ===== Rejections =====
 
+/// Missing request header
 #[derive(Debug)]
-pub(crate) struct MissingHeader(&'static str);
+pub struct MissingHeader(&'static str);
 
 impl ::std::fmt::Display for MissingHeader {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -219,8 +220,9 @@ impl StdError for MissingHeader {
     }
 }
 
+/// Invalid request header
 #[derive(Debug)]
-pub(crate) struct InvalidHeader(&'static str);
+pub struct InvalidHeader(&'static str);
 
 impl ::std::fmt::Display for InvalidHeader {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {

--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -21,7 +21,7 @@ pub fn query<T: DeserializeOwned + Send>() -> impl Filter<Extract = One<T>, Erro
 
         serde_urlencoded::from_str(query_string).map_err(|e| {
             debug!("failed to decode query string '{}': {:?}", query_string, e);
-            reject::known(InvalidQuery)
+            reject::known(InvalidQuery(()))
         })
     })
 }
@@ -33,13 +33,13 @@ pub fn raw() -> impl Filter<Extract = One<String>, Error = Rejection> + Copy {
             .query()
             .map(|q| q.to_owned())
             .map(Ok)
-            .unwrap_or_else(|| Err(reject::known(InvalidQuery)))
+            .unwrap_or_else(|| Err(reject::known(InvalidQuery(()))))
     })
 }
 
 /// Invalid query
 #[derive(Debug)]
-pub struct InvalidQuery;
+pub struct InvalidQuery(());
 
 impl ::std::fmt::Display for InvalidQuery {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {

--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -37,8 +37,9 @@ pub fn raw() -> impl Filter<Extract = One<String>, Error = Rejection> + Copy {
     })
 }
 
+/// Invalid query
 #[derive(Debug)]
-pub(crate) struct InvalidQuery;
+pub struct InvalidQuery;
 
 impl ::std::fmt::Display for InvalidQuery {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {

--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -1,7 +1,5 @@
 //! Query Filters
 
-use std::error::Error as StdError;
-
 use serde::de::DeserializeOwned;
 use serde_urlencoded;
 
@@ -21,7 +19,7 @@ pub fn query<T: DeserializeOwned + Send>() -> impl Filter<Extract = One<T>, Erro
 
         serde_urlencoded::from_str(query_string).map_err(|e| {
             debug!("failed to decode query string '{}': {:?}", query_string, e);
-            reject::known(InvalidQuery(()))
+            reject::invalid_query()
         })
     })
 }
@@ -33,22 +31,6 @@ pub fn raw() -> impl Filter<Extract = One<String>, Error = Rejection> + Copy {
             .query()
             .map(|q| q.to_owned())
             .map(Ok)
-            .unwrap_or_else(|| Err(reject::known(InvalidQuery(()))))
+            .unwrap_or_else(|| Err(reject::invalid_query()))
     })
-}
-
-/// Invalid query
-#[derive(Debug)]
-pub struct InvalidQuery(());
-
-impl ::std::fmt::Display for InvalidQuery {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        f.write_str("Invalid query string")
-    }
-}
-
-impl StdError for InvalidQuery {
-    fn description(&self) -> &str {
-        "Invalid query string"
-    }
 }

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -51,7 +51,7 @@ use tokio::{clock::now, timer::Delay};
 use self::sealed::{
     BoxedServerSentEvent, EitherServerSentEvent, SseError, SseField, SseFormat, SseWrapper,
 };
-use super::{header, header::MissingHeader};
+use super::header;
 use filter::One;
 use reply::Response;
 use {Filter, Rejection, Reply};
@@ -293,7 +293,7 @@ where
     header::header("last-event-id")
         .map(Some)
         .or_else(|rejection: Rejection| {
-            if rejection.find_cause::<MissingHeader>().is_some() {
+            if rejection.find_cause::<::reject::MissingHeader>().is_some() {
                 return Ok((None,));
             }
             Err(rejection)
@@ -322,7 +322,7 @@ pub fn sse() -> impl Filter<Extract = One<Sse>, Error = Rejection> + Copy {
         .and(
             header::exact_ignore_case("connection", "keep-alive").or_else(
                 |rejection: Rejection| {
-                    if rejection.find_cause::<MissingHeader>().is_some() {
+                    if rejection.find_cause::<::reject::MissingHeader>().is_some() {
                         return Ok(());
                     }
                     Err(rejection)

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -78,6 +78,30 @@ pub fn not_found() -> Rejection {
     }
 }
 
+// 400 Bad Request
+#[inline]
+pub(crate) fn invalid_query() -> Rejection {
+    known(InvalidQuery(()))
+}
+
+// 400 Bad Request
+#[inline]
+pub(crate) fn missing_header(name: &'static str) -> Rejection {
+    known(MissingHeader(name))
+}
+
+// 400 Bad Request
+#[inline]
+pub(crate) fn invalid_header(name: &'static str) -> Rejection {
+    known(InvalidHeader(name))
+}
+
+// 400 Bad Request
+#[inline]
+pub(crate) fn missing_cookie(name: &'static str) -> Rejection {
+    known(MissingCookie(name))
+}
+
 // 405 Method Not Allowed
 #[inline]
 pub(crate) fn method_not_allowed() -> Rejection {
@@ -368,13 +392,13 @@ impl Rejections {
             Rejections::Known(ref e) => {
                 if e.is::<MethodNotAllowed>() {
                     StatusCode::METHOD_NOT_ALLOWED
-                } else if e.is::<::header::InvalidHeader>() {
+                } else if e.is::<InvalidHeader>() {
                     StatusCode::BAD_REQUEST
-                } else if e.is::<::header::MissingHeader>() {
+                } else if e.is::<MissingHeader>() {
                     StatusCode::BAD_REQUEST
-                } else if e.is::<::cookie::MissingCookie>() {
+                } else if e.is::<MissingCookie>() {
                     StatusCode::BAD_REQUEST
-                } else if e.is::<::query::InvalidQuery>() {
+                } else if e.is::<InvalidQuery>() {
                     StatusCode::BAD_REQUEST
                 } else if e.is::<LengthRequired>() {
                     StatusCode::LENGTH_REQUIRED
@@ -505,6 +529,22 @@ impl fmt::Debug for Rejections {
     }
 }
 
+/// Invalid query
+#[derive(Debug)]
+struct InvalidQuery(());
+
+impl ::std::fmt::Display for InvalidQuery {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        f.write_str("Invalid query string")
+    }
+}
+
+impl StdError for InvalidQuery {
+    fn description(&self) -> &str {
+        "Invalid query string"
+    }
+}
+
 /// HTTP method not allowed
 #[derive(Debug)]
 pub struct MethodNotAllowed(());
@@ -566,6 +606,55 @@ impl fmt::Display for UnsupportedMediaType {
 impl StdError for UnsupportedMediaType {
     fn description(&self) -> &str {
         "The request's content-type is not supported"
+    }
+}
+
+/// Missing request header
+#[derive(Debug)]
+pub struct MissingHeader(&'static str);
+
+impl ::std::fmt::Display for MissingHeader {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "Missing request header '{}'", self.0)
+    }
+}
+
+impl StdError for MissingHeader {
+    fn description(&self) -> &str {
+        "Missing request header"
+    }
+}
+
+/// Invalid request header
+#[derive(Debug)]
+pub struct InvalidHeader(&'static str);
+
+impl ::std::fmt::Display for InvalidHeader {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "Invalid request header '{}'", self.0)
+    }
+}
+
+impl StdError for InvalidHeader {
+    fn description(&self) -> &str {
+        "Invalid request header"
+    }
+}
+
+
+/// Missing cookie
+#[derive(Debug)]
+pub struct MissingCookie(&'static str);
+
+impl ::std::fmt::Display for MissingCookie {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "Missing request cookie '{}'", self.0)
+    }
+}
+
+impl StdError for MissingCookie {
+    fn description(&self) -> &str {
+        "Missing request cookie"
     }
 }
 

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -505,8 +505,9 @@ impl fmt::Debug for Rejections {
     }
 }
 
+/// HTTP method not allowed
 #[derive(Debug)]
-struct MethodNotAllowed;
+pub struct MethodNotAllowed;
 
 impl fmt::Display for MethodNotAllowed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -520,8 +521,9 @@ impl StdError for MethodNotAllowed {
     }
 }
 
+/// A content-length header is required
 #[derive(Debug)]
-struct LengthRequired;
+pub struct LengthRequired;
 
 impl fmt::Display for LengthRequired {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -535,8 +537,9 @@ impl StdError for LengthRequired {
     }
 }
 
+/// The request payload is too large
 #[derive(Debug)]
-struct PayloadTooLarge;
+pub struct PayloadTooLarge;
 
 impl fmt::Display for PayloadTooLarge {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -550,8 +553,9 @@ impl StdError for PayloadTooLarge {
     }
 }
 
+/// The request's content-type is not supported
 #[derive(Debug)]
-struct UnsupportedMediaType;
+pub struct UnsupportedMediaType;
 
 impl fmt::Display for UnsupportedMediaType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -531,7 +531,7 @@ impl fmt::Debug for Rejections {
 
 /// Invalid query
 #[derive(Debug)]
-struct InvalidQuery(());
+pub struct InvalidQuery(());
 
 impl ::std::fmt::Display for InvalidQuery {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -81,19 +81,19 @@ pub fn not_found() -> Rejection {
 // 405 Method Not Allowed
 #[inline]
 pub(crate) fn method_not_allowed() -> Rejection {
-    known(MethodNotAllowed)
+    known(MethodNotAllowed(()))
 }
 
 // 411 Length Required
 #[inline]
 pub(crate) fn length_required() -> Rejection {
-    known(LengthRequired)
+    known(LengthRequired(()))
 }
 
 // 413 Payload Too Large
 #[inline]
 pub(crate) fn payload_too_large() -> Rejection {
-    known(PayloadTooLarge)
+    known(PayloadTooLarge(()))
 }
 
 // 415 Unsupported Media Type
@@ -102,7 +102,7 @@ pub(crate) fn payload_too_large() -> Rejection {
 // what can be deserialized.
 #[inline]
 pub(crate) fn unsupported_media_type() -> Rejection {
-    known(UnsupportedMediaType)
+    known(UnsupportedMediaType(()))
 }
 
 #[doc(hidden)]
@@ -507,7 +507,7 @@ impl fmt::Debug for Rejections {
 
 /// HTTP method not allowed
 #[derive(Debug)]
-pub struct MethodNotAllowed;
+pub struct MethodNotAllowed(());
 
 impl fmt::Display for MethodNotAllowed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -523,7 +523,7 @@ impl StdError for MethodNotAllowed {
 
 /// A content-length header is required
 #[derive(Debug)]
-pub struct LengthRequired;
+pub struct LengthRequired(());
 
 impl fmt::Display for LengthRequired {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -539,7 +539,7 @@ impl StdError for LengthRequired {
 
 /// The request payload is too large
 #[derive(Debug)]
-pub struct PayloadTooLarge;
+pub struct PayloadTooLarge(());
 
 impl fmt::Display for PayloadTooLarge {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -555,7 +555,7 @@ impl StdError for PayloadTooLarge {
 
 /// The request's content-type is not supported
 #[derive(Debug)]
-pub struct UnsupportedMediaType;
+pub struct UnsupportedMediaType(());
 
 impl fmt::Display for UnsupportedMediaType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
I'm mostly looking for feedback, this is more a proof of concept rather than the actual solution.

I'm trying to render rejections as a JSON object. For custom errors, it already works totally fine. However, in order to reuse all the existing `Filter` implementations, while being able to capture the actual reason in a custom `recover` function, I felt it was needed to define a few of the existing error types as `pub`.

Btw, everything's awesome, thanks for `warp` :cyclone: