### PR TITLE
Remove 'static lifetime restriction from path function

### DIFF
--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -153,7 +153,7 @@ use route::Route;
 /// let hello = warp::path("hello")
 ///     .map(|| "Hello, World!");
 /// ```
-pub fn path(p: &'static str) -> impl Filter<Extract = (), Error = Rejection> + Copy {
+pub fn path<'a>(p: &'a str) -> impl Filter<Extract = (), Error = Rejection> + Copy +'a {
     assert!(!p.is_empty(), "exact path segments should not be empty");
     assert!(
         !p.contains('/'),


### PR DESCRIPTION
Removed `'static` lifetime restriction from the parameter of [path function](https://docs.rs/warp/0.1.16/warp/filters/path/index.html), now it accepts `&str` with an arbitrary lifetime.

_`'static `restriction might be added intentionally by the api designer, if it is then this PR is useless._

According to [this question ](https://stackoverflow.com/questions/56895824/static-lifetime-for-a-temporary-parameter) in SO, one might want this kind of dynamic usability.

-  Generating input on the fly. 

It can be done with the generic lifetime parameter.