### PR TITLE
Add warp::multipart::form filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ hyper = "0.12.18"
 log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.0-alpha.6"
+multipart = { version = "0.16", default-features = false, features = ["server"] }
 scoped-tls = "1.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use std::error::Error as StdError;
 use std::fmt;
+use std::io;
 
 use hyper::Error as HyperError;
 use tungstenite::Error as WsError;
@@ -20,23 +21,18 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0.as_ref() {
             Kind::Hyper(ref e) => fmt::Display::fmt(e, f),
+            Kind::Multipart(ref e) => fmt::Display::fmt(e, f),
             Kind::Ws(ref e) => fmt::Display::fmt(e, f),
         }
     }
 }
 
 impl StdError for Error {
-    fn description(&self) -> &str {
-        match self.0.as_ref() {
-            Kind::Hyper(ref e) => e.description(),
-            Kind::Ws(ref e) => e.description(),
-        }
-    }
-
     #[allow(deprecated)]
     fn cause(&self) -> Option<&dyn StdError> {
         match self.0.as_ref() {
             Kind::Hyper(ref e) => e.cause(),
+            Kind::Multipart(ref e) => e.cause(),
             Kind::Ws(ref e) => e.cause(),
         }
     }
@@ -44,6 +40,7 @@ impl StdError for Error {
 
 pub(crate) enum Kind {
     Hyper(HyperError),
+    Multipart(io::Error),
     Ws(WsError),
 }
 
@@ -51,6 +48,7 @@ impl fmt::Debug for Kind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Kind::Hyper(ref e) => fmt::Debug::fmt(e, f),
+            Kind::Multipart(ref e) => fmt::Debug::fmt(e, f),
             Kind::Ws(ref e) => fmt::Debug::fmt(e, f),
         }
     }

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -222,6 +222,12 @@ pub struct FullBody {
     chunk: Chunk,
 }
 
+impl FullBody {
+    pub(super) fn into_chunk(self) -> Chunk {
+        self.chunk
+    }
+}
+
 impl Buf for FullBody {
     #[inline]
     fn remaining(&self) -> usize {

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -13,6 +13,7 @@ pub mod fs;
 pub mod header;
 pub mod log;
 pub mod method;
+pub mod multipart;
 pub mod path;
 pub mod query;
 pub mod reply;

--- a/src/filters/multipart.rs
+++ b/src/filters/multipart.rs
@@ -1,0 +1,173 @@
+//! Multipart body filters
+//!
+//! Filters that extract a multipart body for a route.
+
+use std::fmt;
+use std::io::{Cursor, Read};
+
+use futures::{Async, Future, Poll, Stream};
+use headers::ContentType;
+use mime::Mime;
+use multipart_c::server::Multipart;
+
+use filter::{FilterBase, Filter};
+use reject::{self, Rejection};
+
+// If not otherwise configured, default to 2MB.
+const DEFAULT_FORM_DATA_MAX_LENGTH: u64 = 1024 * 1024 * 2;
+
+/// A `Filter` to extract a `multipart/form-data` body from a request.
+///
+/// Create with the `warp::multipart::form()` function.
+#[derive(Debug, Clone)]
+pub struct FormOptions {
+    max_length: u64,
+}
+
+/// A `Stream` of multipart/form-data `Part`s.
+///
+/// Extracted with a `warp::multipart::form` filter.
+pub struct FormData {
+    inner: Multipart<Cursor<::hyper::Chunk>>,
+}
+
+/// A single "part" of a multipart/form-data body.
+///
+/// Yielded from the `FormData` stream.
+pub struct Part {
+    name: String,
+    filename: Option<String>,
+    content_type: Option<String>,
+    data: Option<Vec<u8>>,
+}
+
+/// Create a `Filter` to extact a `multipart/form-data` body from a request.
+///
+/// The extracted `FormData` type is a `Stream` of `Part`s, and each `Part`
+/// in turn is a `Stream` of bytes.
+pub fn form() -> FormOptions {
+    FormOptions {
+        max_length: DEFAULT_FORM_DATA_MAX_LENGTH,
+    }
+}
+
+// ===== impl Form =====
+
+impl FormOptions {
+    /// Set the maximum byte length allowed for this body.
+    ///
+    /// Defaults to 2MB.
+    pub fn max_length(mut self, max: u64) -> Self {
+        self.max_length = max;
+        self
+    }
+}
+
+
+type FormFut = Box<dyn Future<Item = (FormData,), Error = Rejection> + Send>;
+
+impl FilterBase for FormOptions {
+    type Extract = (FormData,);
+    type Error = Rejection;
+    type Future = FormFut;
+
+    fn filter(&self) -> Self::Future {
+        let boundary = super::header::header2::<ContentType>()
+            .and_then(|ct| {
+                let mime = Mime::from(ct);
+                mime.get_param("boundary")
+                    .map(|v| v.to_string())
+                    .ok_or_else(|| reject::invalid_header("content-type"))
+            });
+
+        let filt = super::body::content_length_limit(self.max_length)
+            .and(boundary)
+            .and(super::body::concat())
+            .map(|boundary, body: super::body::FullBody| {
+                FormData {
+                    inner: Multipart::with_body(Cursor::new(body.into_chunk()), boundary),
+                }
+            });
+
+        let fut = filt.filter();
+
+        Box::new(fut)
+    }
+}
+
+// ===== impl FormData =====
+
+impl fmt::Debug for FormData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("FormData").finish()
+    }
+}
+
+impl Stream for FormData {
+    type Item = Part;
+    type Error = ::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        match self.inner.read_entry() {
+            Ok(Some(mut field)) => {
+                let mut data = Vec::new();
+                field.data
+                    .read_to_end(&mut data)
+                    .map_err(::error::Kind::Multipart)?;
+                Ok(Async::Ready(Some(Part {
+                    name: field.headers.name.to_string(),
+                    filename: field.headers.filename,
+                    content_type: field.headers.content_type.map(|m| m.to_string()),
+                    data: Some(data),
+                })))
+            },
+            Ok(None) => Ok(Async::Ready(None)),
+            Err(e) => Err(::error::Kind::Multipart(e).into())
+        }
+    }
+}
+
+// ===== impl Part =====
+
+impl Part {
+    /// Get the name of this part.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the filename of this part, if present.
+    pub fn filename(&self) -> Option<&str> {
+        self.filename.as_ref().map(|s| &**s)
+    }
+
+    /// Get the content-type of this part, if present.
+    pub fn content_type(&self) -> Option<&str> {
+        self.content_type.as_ref().map(|s| &**s)
+    }
+}
+
+impl fmt::Debug for Part {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut builder = f.debug_struct("Part");
+        builder.field("name", &self.name);
+
+        if let Some(ref filename) = self.filename {
+            builder.field("filename", filename);
+        }
+
+        if let Some(ref mime) = self.content_type {
+            builder.field("content_type", mime);
+        }
+
+        builder.finish()
+    }
+}
+
+impl Stream for Part {
+    type Item = Vec<u8>;
+    type Error = ::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        Ok(Async::Ready(self.data.take()))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ extern crate hyper;
 extern crate log as logcrate;
 extern crate mime;
 extern crate mime_guess;
+extern crate multipart as multipart_c;
 #[macro_use]
 extern crate scoped_tls;
 #[cfg(feature = "tls")]
@@ -151,6 +152,7 @@ pub use self::filters::{
     method::{delete, get, method, post, put},
     method::{delete2, get2, post2, put2},
     method::{head, options, patch},
+    multipart,
     path,
     // the index() function
     path::index,

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -1,0 +1,44 @@
+#![deny(warnings)]
+extern crate futures;
+extern crate pretty_env_logger;
+extern crate warp;
+
+use futures::{Future, Stream};
+use warp::Filter;
+
+#[test]
+fn form_fields() {
+    let _ = pretty_env_logger::try_init();
+
+    let route = warp::multipart::form()
+        .and_then(|form: warp::multipart::FormData| {
+            // Collect the fields into (name, value): (String, Vec<u8>)
+            form
+                .and_then(|part| {
+                    let name = part.name().to_string();
+                    part.concat2().map(move |value| (name, value))
+                })
+                .collect()
+                .map_err(|e| -> warp::Rejection {
+                    panic!("multipart error: {:?}", e);
+                })
+        });
+
+    let boundary = "--abcdef1234--";
+    let body = format!("\
+        --{0}\r\n\
+        content-disposition: form-data; name=\"foo\"\r\n\r\n\
+        bar\r\n\
+        --{0}--\r\n\
+    ", boundary);
+
+    let req = warp::test::request()
+        .method("POST")
+        .header("content-length", body.len())
+        .header("content-type", format!("multipart/form-data; boundary={}", boundary))
+        .body(body);
+
+    let vec = req.filter(&route).unwrap();
+    assert_eq!(&vec[0].0, "foo");
+    assert_eq!(&vec[0].1, b"bar");
+}


### PR DESCRIPTION
This provides initial `multipart/form-data` support. This is more just a raw interface, providing a `Stream` of `Part`s that are in turn `Stream`s of bytes. The internal implementation isn't optimized, just holding the full form in memory, but is exposed as `Stream`s to allow for streaming support to be added later.

Closes #40 