### PR TITLE
Allow extracting the binary data out of a ws::Message without copying.

### DIFF
--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -400,6 +400,11 @@ impl Message {
             _ => unreachable!(),
         }
     }
+
+    /// Destructure this message into binary data.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.inner.into_data()
+    }
 }
 
 impl fmt::Debug for Message {

--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -412,3 +412,10 @@ impl fmt::Debug for Message {
         fmt::Debug::fmt(&self.inner, f)
     }
 }
+
+
+impl Into<Vec<u8>> for Message {
+    fn into(self) -> Vec<u8> {
+        self.into_bytes()
+    }
+}


### PR DESCRIPTION
Until now the API only allowed getting a reference. For code wanting to work on websocket connections, regardless of whether they're provided by warp, tungstenite, tokio-tungstenite or other websocket libraries this is a problem because the type from warp has to be kept all the way through algorithms to avoid making a needless copy of all the data.

This adds a new method to `warp::ws::Message` called `into_bytes` which will return a `Vec<u8>` of the inner data.

Note that this alleviates this problem for code wanting to operate on binary messages. However, there could and probably should also be a a similar method to extract string messages without copying.

I chose to delegate the call to the inner tungstenite message because I feel tungstenite has [better implementations](https://github.com/snapview/tungstenite-rs/blob/master/src/protocol/message.rs#L261) of these conversions, rather than modifying the `as_bytes` method which can panic. Following a similar implementation as `as_bytes` is a possible alternative. Note that tungstenite will also transform data from message types other than `String` and `Binary`. I figure that if the user wants to avoid that, they have to check the type, which
they would have to do in the alternative impl as well, since otherwise it can panic.

The second commit adds an impl for `Into<Vec<u8>>` for `warp::ws::Message`.

This could be done for string conversions too, but since those are fallible and tungstenite has their own error type, we would just need to convert the error type.

This pull request deals with very specific problem but there are others:
- there is an inconsistency between the `to_str` method which returns an error when called on a message variant for which the operation is not supported and the `as_bytes` method which will panic. Note also the inconsistency in naming.
- the `is_pong` method is missing. Unless there is a specific reason for this, it should probably be added for consistency in case people want to wrap `ws::Message`, eg. to abstract out with differences from other websocket libraries.
- there is currently no way to recover the code and reason of a close message.

See also: #257

All in all, the tungstenite `Message` is superior in both functionality and implementation. I would be in favor of an `Into` implementation or simply an `into_inner` method. I understand that this means that changing from tungstenite to another websocket implementation becomes a breaking change. However at this early stage in development, avoiding this at all costs leads to a degraded API while breaking changes will be necessary in the future anyway to fix it. I understand the desire hide implementation details, but I would propose to postpone that until a stable fully featured and clean API can be offered as an alternative.

If it's desirable to fix some of the other issues mentioned above, I can add more commits to this pull request or file another one. 

There are no unit tests provided with this pull request.