### PR TITLE
Add query parameters to the todos example.

### DIFF
--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -61,6 +61,7 @@ fn main() {
     // (and to reject huge payloads)...
     let json_body = warp::body::content_length_limit(1024 * 16).and(warp::body::json());
 
+    // For `GET /todos` also allow optional query parameters to allow for paging of TODOs.
     let list_options = warp::query::<ListOptions>();
 
     // Next, we'll define each our 4 endpoints:
@@ -114,10 +115,9 @@ struct ListOptions {
     limit: Option<usize>,
 }
 
-/// GET /todos
+/// GET /todos with optional query parameters of limit and offset
 fn list_todos(opts: ListOptions, db: Db) -> impl warp::Reply {
-    // Just return a JSON array of todos, applying the limit and offset (while making sure there
-    // are no out of bounds slicing).
+    // Just return a JSON array of todos, applying the limit and offset.
     let todos = db.lock().unwrap();
     let todos: Vec<Todo> = todos
         .clone()

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -61,7 +61,7 @@ fn main() {
     // (and to reject huge payloads)...
     let json_body = warp::body::content_length_limit(1024 * 16).and(warp::body::json());
 
-    // For `GET /todos` also allow optional query parameters to allow for paging of TODOs.
+    // For `GET /todos` also allow optional query parameters to allow for paging of Todos.
     let list_options = warp::query::<ListOptions>();
 
     // Next, we'll define each our 4 endpoints:

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -61,7 +61,7 @@ fn main() {
     // (and to reject huge payloads)...
     let json_body = warp::body::content_length_limit(1024 * 16).and(warp::body::json());
 
-    let list_options = warp::filters::query::query::<ListOptions>();
+    let list_options = warp::query::<ListOptions>();
 
     // Next, we'll define each our 4 endpoints:
 

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -7,7 +7,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate warp;
 
-use std::{env, cmp};
+use std::env;
 use std::sync::{Arc, Mutex};
 use warp::{http::StatusCode, Filter};
 
@@ -119,10 +119,8 @@ fn list_todos(opts: ListOptions, db: Db) -> impl warp::Reply {
     // Just return a JSON array of todos, applying the limit and offset (while making sure there
     // are no out of bounds slicing).
     let guard = db.lock().unwrap();
-    let todos = &*guard;
-    let start = cmp::min(cmp::max(opts.offset.unwrap_or(0), 0), todos.len());
-    let end = cmp::min(opts.limit.map(|l| l + start).unwrap_or(std::usize::MAX), todos.len());
-    warp::reply::json(&todos[start..end].to_vec())
+    let todos: Vec<Todo> = guard.clone().into_iter().skip(opts.offset.unwrap_or(0)).take(opts.limit.unwrap_or(std::usize::MAX)).collect();
+    warp::reply::json(&todos)
 }
 
 /// POST /todos with JSON body

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -118,8 +118,13 @@ struct ListOptions {
 fn list_todos(opts: ListOptions, db: Db) -> impl warp::Reply {
     // Just return a JSON array of todos, applying the limit and offset (while making sure there
     // are no out of bounds slicing).
-    let guard = db.lock().unwrap();
-    let todos: Vec<Todo> = guard.clone().into_iter().skip(opts.offset.unwrap_or(0)).take(opts.limit.unwrap_or(std::usize::MAX)).collect();
+    let todos = db.lock().unwrap();
+    let todos: Vec<Todo> = todos
+        .clone()
+        .into_iter()
+        .skip(opts.offset.unwrap_or(0))
+        .take(opts.limit.unwrap_or(std::usize::MAX))
+        .collect();
     warp::reply::json(&todos)
 }
 

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -115,7 +115,7 @@ struct ListOptions {
     limit: Option<usize>,
 }
 
-/// GET /todos with optional query parameters of limit and offset
+/// GET /todos?offset=3&limit=5
 fn list_todos(opts: ListOptions, db: Db) -> impl warp::Reply {
     // Just return a JSON array of todos, applying the limit and offset.
     let todos = db.lock().unwrap();


### PR DESCRIPTION
Previously, none of the examples used query parameters.