### PR TITLE
Fix cors filter in conjunction with log filter

### DIFF
--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -415,7 +415,7 @@ mod internal {
     use reject::{CombineRejection, Rejection};
     use route;
 
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     pub struct CorsFilter<F> {
         pub(super) config: Arc<Configured>,
         pub(super) inner: F,

--- a/tests/cors.rs
+++ b/tests/cors.rs
@@ -148,5 +148,24 @@ fn success() {
     assert_eq!(res.headers().get("access-control-allow-methods"), None);
     let exposed_headers = &res.headers()["access-control-expose-headers"];
     assert!(exposed_headers == "x-header1, x-header2" || exposed_headers == "x-header2, x-header1");
+}
 
+#[test]
+fn with_log() {
+    let cors = warp::cors()
+        .allow_any_origin()
+        .allow_methods(&[Method::GET]);
+
+    let route = warp::any()
+        .map(warp::reply)
+        .with(cors)
+        .with(warp::log("cors test"));
+
+    let res = warp::test::request()
+        .method("OPTIONS")
+        .header("origin", "warp")
+        .header("access-control-request-method", "GET")
+        .reply(&route);
+
+    assert_eq!(res.status(), 200);
 }


### PR DESCRIPTION
Using the cors filter in conjunction with the log filter resulted in a compilation error as the Clone trait was not satisfied for `cors::internal::CorsFilter`. This is a naive attempt to fix it by
deriving Clone.

* derive Clone on CorsFilter
* introduce regression test for cors with log filter

***

Also provided a minimal case that fails over [here](https://github.com/xla/warp-cors-log-testcase) with the error in the README.