### PR TITLE
Filter::debug_boxed()

### DIFF
--- a/examples/returning.rs
+++ b/examples/returning.rs
@@ -15,6 +15,13 @@ pub fn index_filter() -> impl Filter<Extract = (&'static str,), Error = Rejectio
     warp::path::end().map(|| "Index page")
 }
 
+// Option 3: box only for debug builds
+// In debug builds, this will return a BoxedFilter like Option 1
+// but in release builds it will return the filter as in Option 2.
+pub fn other_filter() -> impl Filter<Extract = (&'static str,), Error = Rejection> + Clone {
+    warp::path::end().map(|| "Other page").debug_boxed()
+}
+
 pub fn main() {
     let routes = index_filter().or(assets_filter());
     warp::serve(routes).run(([127, 0, 0, 1], 3030));

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -400,6 +400,34 @@ pub trait Filter: FilterBase {
     {
         BoxedFilter::new(self)
     }
+
+    /// Boxes the Filter only for debug builds.
+    /// For release builds, this simply returns the filter.
+    ///
+    /// Compiling many composed filters may be slow because
+    /// it uses a lot of generics under the hood. Boxing filters
+    /// speeds up compile times but may make it slightly slower
+    /// at runtime. This allows you to speed up compilation for debug
+    /// builds while avoiding the runtime penalty for release builds.
+    #[cfg(debug_assertions)]
+    fn debug_boxed(self) -> BoxedFilter<Self::Extract>
+    where
+        Self: Sized + Send + Sync + 'static,
+        Self::Extract: Send,
+        Self::Error: Into<Rejection>,
+    {
+        BoxedFilter::new(self)
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn debug_boxed(self) -> Self
+    where
+        Self: Sized + Send + Sync + 'static,
+        Self::Extract: Send,
+        Self::Error: Into<Rejection>,
+    {
+        self
+    }
 }
 
 impl<T: FilterBase> Filter for T {}


### PR DESCRIPTION
Compiling many composed filters can be very slow. Boxing speeds up compile times but slows down the program at runtime. This adds a method to box the Filter only for debug builds while leaving it unchanged for release builds.

Related to https://github.com/seanmonstar/warp/issues/32