### PR TITLE
Add ability to send Ping ws Messages

### DIFF
--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -329,9 +329,7 @@ impl Sink for WebSocket {
             Err(::tungstenite::Error::Io(ref err)) if err.kind() == WouldBlock => {
                 Ok(Async::NotReady)
             }
-            Err(::tungstenite::Error::ConnectionClosed) => {
-                Ok(Async::Ready(()))
-            }
+            Err(::tungstenite::Error::ConnectionClosed) => Ok(Async::Ready(())),
             Err(err) => {
                 debug!("websocket close error: {}", err);
                 Err(Kind::Ws(err).into())
@@ -369,6 +367,13 @@ impl Message {
     pub fn binary<V: Into<Vec<u8>>>(v: V) -> Message {
         Message {
             inner: protocol::Message::binary(v),
+        }
+    }
+
+    /// Construct a new Ping `Message`.
+    pub fn ping<V: Into<Vec<u8>>>(v: V) -> Message {
+        Message {
+            inner: protocol::Message::Ping(v.into()),
         }
     }
 
@@ -420,7 +425,6 @@ impl fmt::Debug for Message {
         fmt::Debug::fmt(&self.inner, f)
     }
 }
-
 
 impl Into<Vec<u8>> for Message {
     fn into(self) -> Vec<u8> {


### PR DESCRIPTION
This (very small) PR adds the ability to send WebSocket `Ping` messages. This functionality is built into Tungstenite, but was not previously exposed in Warp's public API.

The idea behind this PR is to support the use-case described in #269.  Ultimately, it would be helpful for Warp to expose functionality that automates sending of pings (to parallel the SSE `keep_alive` method).  This PR doesn't achieve that, but lays the foundation for future work along those lines and, in the meantime allows users to manually send pings (for example, one can use this PR with a timer/loop to achieve a keep-alive ping slightly more verbosely).