### PR TITLE
Better document two foot-guns

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,37 @@
+# Examples
+
+Welcome to the examples! These show off `warp`'s functionality and explain how to use it.
+
+## Getting Started
+
+- [`hello.rs`](./hello.rs) - Just a basic "Hello World" API
+- [`routing.rs`](./routing.rs) - Builds up a more complex set of routes and shows how to combine filters
+- [`body.rs`](./body.rs) - What's a good API without parsing data from the request body?
+- [`headers.rs`](./headers.rs) - Parsing data from the request headers
+- [`errors.rs`](./errors.rs) - Your APIs are obviously perfect, but for silly others who call them incorrectly you'll want to define errors for them
+- [`futures.rs`](./futures.rs) - Wait, wait! ... Or how to integrate futures into filters
+- [`todos.rs`](./todos.rs) - Putting this all together with a proper app
+
+## Further Use Cases
+
+### Serving HTML and Other Files
+
+- [`file.rs`](./file.rs) - Serving static files
+- [`dir.rs`](./dir.rs) - Or a whole directory of files
+- [`handlebars_template.rs`](./handlebars_template.rs) - Using Handlebars to fill in an HTML template
+
+### Websockets
+
+Hooray! `warp` also includes built-in support for WebSockets
+
+- [`websockets.rs`](./websockets.rs) - Basic handling of a WebSocket upgrade
+- [`websockets_chat.rs`](./websockets_chat.rs) - Full WebSocket app
+
+### Server-Side Events
+
+- [`sse.rs`](./sse.rs) - Basic Server-Side Event
+- [`sse_chat.rs`](./sse_chat.rs) - Full SSE app
+
+### TLS
+
+- [`tls.rs`](./tls.rs) - can i haz security?

--- a/examples/routing.rs
+++ b/examples/routing.rs
@@ -60,6 +60,14 @@ fn main() {
     // GET /math/:u16/times/:u16
     let math = warp::path("math").and(sum.or(times));
 
+    // We can use the end() filter to match a shorter path
+    let help = warp::path("math")
+        // Careful! Omitting the following line would make this filter match
+        // requests to /math/sum/:u32/:u32 and /math/:u16/times/:u16
+        .and(warp::path::end())
+        .map(|| "This is the Math API. Try calling /math/sum/:u32/:u32 or /math/:u16/times/:u16");
+    let math = help.or(math);
+
     // Let's let people know that the `sum` and `times` routes are under `math`.
     let sum = sum.map(|output| format!("(This route has moved to /math/sum/:u16/:u16) {}", output));
     let times =

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -64,6 +64,9 @@ fn main() {
     // For `GET /todos` also allow optional query parameters to allow for paging of Todos.
     let list_options = warp::query::<ListOptions>();
 
+    // We'll make one of our endpoints admin-only to show how authentication filters are used
+    let admin_only = warp::header::exact("authorization", "Bearer admin");
+
     // Next, we'll define each our 4 endpoints:
 
     // `GET /todos`
@@ -90,6 +93,11 @@ fn main() {
     // `DELETE /todos/:id`
     let delete = warp::delete2()
         .and(todos_id)
+        // It is important to put the auth check _after_ the path filters.
+        // If we put the auth check before, the request `PUT /todos/invalid-string`
+        // would try this filter and reject because the authorization header doesn't match,
+        // rather because the param is wrong for that other path.
+        .and(admin_only.clone())
         .and(db.clone())
         .and_then(delete_todo);
 

--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -125,6 +125,11 @@
 //!     .or(bye)
 //!     .or(math);
 //! ```
+//!
+//! Note that you will generally want path filters to come **before** other filters
+//! like `body` or `headers`. If a different type of filter comes first, a request
+//! with an invalid body for route `/right-path-wrong-body` may try matching against `/wrong-path`
+//! and return the error from `/wrong-path` instead of the correct body-related error.
 
 use std::fmt;
 use std::str::FromStr;
@@ -144,6 +149,10 @@ use route::Route;
 ///     - [`end()`](./fn.end.html) should be used to match the end of a path to avoid having
 ///         filters for shorter paths like `/math` unintentionally match a longer
 ///         path such as `/math/sum`
+///     - path-related filters should generally come **before** other types of filters, such
+///         as those checking headers or body types. Including those other filters before
+///         the path checks may result in strange errors being returned because a given request
+///         does not match the parameters for a completely separate route.
 ///
 /// # Panics
 ///


### PR DESCRIPTION
While switching Interledger.rs to `warp`, we made two subtle and hard-to-debug mistakes:
- failing to include the `warp::path::end()` filter and thus having a shorter route like `/math` accidentally match a request for a longer path like `/math/sum/:u32/:u32`
- putting auth checks before the path-related filters and winding up with auth-related errors when a request for a completely different route had an invalid body

This attempts to document those two issues in the rustdoc and examples, though there are probably some other places this type of gotcha could be documented.

This also includes a README for the `examples` directory to point newcomers to the examples in a specific order.