### PR TITLE
Fix broken link in reject::custom docs

### DIFF
--- a/src/reject.rs
+++ b/src/reject.rs
@@ -140,7 +140,7 @@ pub fn server_error() -> Rejection {
 /// A [`recover`][] filter should convert this `Rejection` into a `Reply`,
 /// or else this will be returned as a `500 Internal Server Error`.
 ///
-/// [`recover`]: ../../trait.Filter.html#method.recover
+/// [`recover`]: ../trait.Filter.html#method.recover
 pub fn custom(err: impl Into<Cause>) -> Rejection {
     Rejection::custom(err.into())
 }


### PR DESCRIPTION
Is the [link to the `recover` filter](https://github.com/seanmonstar/warp/blob/0828822e834d6837091813ad3efe2a03a17d0da7/src/reject.rs#L143) on the [reject::custom](https://docs.rs/warp/0.1.20/warp/reject/fn.custom.html) page moving up one directory too many?

On my browser the path resolves to https://docs.rs/warp/0.1.20/trait.Filter.html#method.recover which doesn't lead anywhere useful. If I change `warp/0.1.20/` to `warp/0.1.20/warp`, then it seems to work:
https://docs.rs/warp/0.1.20/warp/trait.Filter.html#method.recover.