### PR TITLE
Alter Filter::{or, or_else, recover} to require Self::Error=Rejection

### DIFF
--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -98,8 +98,8 @@
 //!
 //! ```
 //! # use warp::Filter;
-//! # let sum = warp::any().map(warp::reply);
-//! # let times = sum.clone();
+//! # let sum = warp::path("sum");
+//! # let times = warp::path("times");
 //! // GET /math/sum/:u32/:u32
 //! // GET /math/:u16/times/:u16
 //! let math = warp::path("math")
@@ -111,7 +111,7 @@
 //!
 //! ```
 //! # use warp::Filter;
-//! # let hi = warp::any().map(warp::reply);
+//! # let hi = warp::path("hi");
 //! # let hello_from_warp = hi.clone();
 //! # let bye = hi.clone();
 //! # let math = hi.clone();

--- a/tests/filter.rs
+++ b/tests/filter.rs
@@ -100,10 +100,15 @@ async fn map() {
 async fn unify() {
     let _ = pretty_env_logger::try_init();
 
-    let a = warp::any().map(|| 1);
-    let b = warp::any().map(|| 2);
-    let or = a.or(b).unify();
+    let a = warp::path::param::<u32>();
+    let b = warp::path::param::<u32>();
+    let f = a.or(b).unify();
 
-    let ex = warp::test::request().filter(&or).await.unwrap();
+    let ex = warp::test::request()
+        .path("/1")
+        .filter(&f)
+        .await
+        .unwrap();
+
     assert_eq!(ex, 1);
 }


### PR DESCRIPTION
Technically a breaking change, but in practice, the other only error
type is `Never`, and so `warp::any().or_else(..)` didn't make sense.