### PR TITLE
Change Server::tls(path, path) to return a builder instead

### DIFF
--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -10,8 +10,13 @@ async fn main() {
     // Match any request and return hello world!
     let routes = warp::any().map(|| "Hello, World!");
 
+    let mut tls_config = warp::tls::TlsConfigBuilder::new();
+    tls_config
+        .set_cert_path("examples/tls/cert.pem").unwrap()
+        .set_key_path("examples/tls/key.rsa").unwrap();
+
     warp::serve(routes)
-        .tls("examples/tls/cert.pem", "examples/tls/key.rsa")
+        .tls(&mut tls_config)
         .run(([127, 0, 0, 1], 3030)).await;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ mod route;
 mod server;
 pub mod test;
 #[cfg(feature = "tls")]
-mod tls;
+pub mod tls;
 mod transport;
 
 pub use self::error::Error;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use std::error::Error as StdError;
 use std::net::SocketAddr;
 #[cfg(feature = "tls")]
-use std::path::Path;
+use crate::tls::TlsConfigBuilder;
 use std::sync::Arc;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -339,9 +339,8 @@ where
     ///
     /// *This function requires the `"tls"` feature.*
     #[cfg(feature = "tls")]
-    pub fn tls(self, cert: impl AsRef<Path>, key: impl AsRef<Path>) -> TlsServer<S> {
-        let tls = crate::tls::configure(cert.as_ref(), key.as_ref());
-
+    pub fn tls(self, builder: &mut TlsConfigBuilder) -> TlsServer<S> {
+        let tls = builder.build().expect("tls error");
         TlsServer { server: self, tls }
     }
 }


### PR DESCRIPTION
on #223 you mention the change should make `Server::tls` to return a builder instead. 
To maintain the same sort ergonomics: arguments being passed, I updated `Server::tls` to receive the builder instead.
If you want, I can change so that `Server::tls` returns the builder, I just have some questions regarding the transition from the builder to `TlsServer`:
should the builder then return `TlsServer` or should these options be added to `TlsServer` instead and not use a builder?
