### PR TITLE
Add `warp::tls::peer_certificates()` filter.

### DIFF
--- a/src/filter/service.rs
+++ b/src/filter/service.rs
@@ -26,10 +26,10 @@ where
     type Reply = FilteredFuture<F::Future>;
 
     #[inline]
-    fn call(&self, req: Request, remote_addr: Option<SocketAddr>) -> Self::Reply {
+    fn call(&self, req: Request, remote_addr: Option<SocketAddr>, tls_peer_certificates: Option<Vec<Vec<u8>>>) -> Self::Reply {
         debug_assert!(!route::is_set(), "nested route::set calls");
 
-        let route = Route::new(req, remote_addr);
+        let route = Route::new(req, remote_addr, tls_peer_certificates);
         let fut = route::set(&route, || self.filter.filter());
         FilteredFuture {
             future: fut,

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -21,5 +21,7 @@ pub mod reply;
 pub mod sse;
 #[cfg(feature = "websocket")]
 pub mod ws;
+#[cfg(feature = "tls")]
+pub mod tls;
 
 pub use crate::filter::BoxedFilter;

--- a/src/filters/tls.rs
+++ b/src/filters/tls.rs
@@ -1,0 +1,24 @@
+//! Tls filters
+
+use std::convert::Infallible;
+
+use crate::filter::{filter_fn_one, Filter};
+
+/// Creates a `Filter` to get the remote tls certificate chain of the connection.
+///
+/// If the underlying connection doesn't have certificates, this will yield
+/// `None`.
+///
+/// # Example
+///
+/// ```
+/// use warp::Filter;
+///
+/// let route = warp::::tls::peer_certificates()
+///     .map(|certs: Option<Vec<Vec<u8>>>| {
+///         println!("peer certificates = {:?}", certs);
+///     });
+/// ```
+pub fn peer_certificates() -> impl Filter<Extract = (Option<Vec<Vec<u8>>>,), Error = Infallible> + Copy {
+    filter_fn_one(|route| futures::future::ok(route.tls_peer_certificates()))
+}

--- a/src/filters/tls.rs
+++ b/src/filters/tls.rs
@@ -13,12 +13,39 @@ use crate::filter::{filter_fn_one, Filter};
 ///
 /// ```
 /// use warp::Filter;
+/// use warp::tls::Certificate;
 ///
-/// let route = warp::::tls::peer_certificates()
-///     .map(|certs: Option<Vec<Vec<u8>>>| {
+/// let route = warp::tls::peer_certificates()
+///     .map(|certs: Option<Vec<Certificate>>| {
 ///         println!("peer certificates = {:?}", certs);
 ///     });
 /// ```
-pub fn peer_certificates() -> impl Filter<Extract = (Option<Vec<Vec<u8>>>,), Error = Infallible> + Copy {
-    filter_fn_one(|route| futures::future::ok(route.tls_peer_certificates()))
+pub fn peer_certificates() -> impl Filter<Extract = (Option<Vec<Certificate>>,), Error = Infallible> + Copy {
+    filter_fn_one(|route| {
+        let certs = route.tls_peer_certificates()
+            .map(|v|
+                v.into_iter()
+                .map(|c| Certificate(c))
+                .collect()
+                );
+
+        futures::future::ok(certs)
+    })
 }
+
+/// This type contains a single certificate by value.
+#[derive(Debug)]
+pub struct Certificate(Vec<u8>);
+
+impl AsRef<[u8]> for Certificate {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Into<Vec<u8>> for Certificate {
+    fn into(self) -> Vec<u8> {
+        self.0
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ mod route;
 mod server;
 pub mod test;
 #[cfg(feature = "tls")]
-mod tls;
+pub mod tls;
 mod transport;
 
 pub use self::error::Error;

--- a/src/route.rs
+++ b/src/route.rs
@@ -34,6 +34,7 @@ pub(crate) struct Route {
     remote_addr: Option<SocketAddr>,
     req: Request,
     segments_index: usize,
+    tls_peer_certificates: Option<Vec<Vec<u8>>>
 }
 
 #[derive(Debug)]
@@ -43,7 +44,7 @@ enum BodyState {
 }
 
 impl Route {
-    pub(crate) fn new(req: Request, remote_addr: Option<SocketAddr>) -> RefCell<Route> {
+    pub(crate) fn new(req: Request, remote_addr: Option<SocketAddr>, tls_peer_certificates: Option<Vec<Vec<u8>>>) -> RefCell<Route> {
         let segments_index = if req.uri().path().starts_with('/') {
             // Skip the beginning slash.
             1
@@ -56,6 +57,7 @@ impl Route {
             remote_addr,
             req,
             segments_index,
+            tls_peer_certificates,
         })
     }
 
@@ -136,5 +138,10 @@ impl Route {
             }
             BodyState::Taken => None,
         }
+    }
+
+    #[cfg(feature = "tls")]
+    pub(crate) fn tls_peer_certificates(&self) -> Option<Vec<Vec<u8>>> {
+        self.tls_peer_certificates.clone()
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -55,8 +55,9 @@ macro_rules! into_service {
         make_service_fn(move |transport| {
             let inner = inner.clone();
             let remote_addr = Transport::remote_addr(transport);
+            let tls_peer_certificates = Transport::tls_peer_certificates(transport);
             future::ok::<_, hyper::Error>(service_fn(move |req| ReplyFuture {
-                inner: inner.call(req, remote_addr),
+                inner: inner.call(req, remote_addr, tls_peer_certificates.clone()),
             }))
         })
     }};
@@ -442,7 +443,7 @@ pub trait IntoWarpService {
 
 pub trait WarpService {
     type Reply: TryFuture + Send;
-    fn call(&self, req: Request, remote_addr: Option<SocketAddr>) -> Self::Reply;
+    fn call(&self, req: Request, remote_addr: Option<SocketAddr>, tls_peer_certificates: Option<Vec<Vec<u8>>>) -> Self::Reply;
 }
 
 // Optimizes better than using Future::then, since it doesn't

--- a/src/test.rs
+++ b/src/test.rs
@@ -113,6 +113,7 @@ use self::inner::OneOrTuple;
 pub fn request() -> RequestBuilder {
     RequestBuilder {
         remote_addr: None,
+        tls_peer_certificates: None,
         req: Request::default(),
     }
 }
@@ -130,6 +131,7 @@ pub fn ws() -> WsBuilder {
 #[derive(Debug)]
 pub struct RequestBuilder {
     remote_addr: Option<SocketAddr>,
+    tls_peer_certificates: Option<Vec<Vec<u8>>>,
     req: Request,
 }
 
@@ -337,7 +339,7 @@ impl RequestBuilder {
         // TODO: de-duplicate this and apply_filter()
         assert!(!route::is_set(), "nested test filter calls");
 
-        let route = Route::new(self.req, self.remote_addr);
+        let route = Route::new(self.req, self.remote_addr, self.tls_peer_certificates);
         let mut fut = route::set(&route, move || f.filter())
             .then(|result| {
                 let res = match result {
@@ -369,7 +371,7 @@ impl RequestBuilder {
     {
         assert!(!route::is_set(), "nested test filter calls");
 
-        let route = Route::new(self.req, self.remote_addr);
+        let route = Route::new(self.req, self.remote_addr, self.tls_peer_certificates);
         let mut fut = route::set(&route, move || f.filter());
         future::poll_fn(move |cx| {
             route::set(&route, || {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -17,7 +17,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::transport::Transport;
 
-pub use crate::filters::tls::peer_certificates;
+pub use crate::filters::tls::{peer_certificates, Certificate};
 
 pub(crate) fn configure(cert: &Path, key: &Path) -> ServerConfig {
     let cert = {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use std::fs::File;
 use std::io::{self, BufReader, Read, Write};
 use std::net::SocketAddr;
@@ -14,6 +16,8 @@ use hyper::server::conn::{AddrIncoming, AddrStream};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::transport::Transport;
+
+pub use crate::filters::tls::peer_certificates;
 
 pub(crate) fn configure(cert: &Path, key: &Path) -> ServerConfig {
     let cert = {
@@ -214,6 +218,13 @@ impl<T: AsyncRead + AsyncWrite + Unpin> AsyncWrite for TlsStream<T> {
 impl<T: Transport + Unpin> Transport for TlsStream<T> {
     fn remote_addr(&self) -> Option<SocketAddr> {
         self.io.inner.remote_addr()
+    }
+    fn tls_peer_certificates(&self) -> Option<Vec<Vec<u8>>> {
+        self.session.get_peer_certificates()
+            .map(|v|
+                v.into_iter()
+                .map(|c| c.0)
+                .collect())
     }
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -8,11 +8,17 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 pub trait Transport: AsyncRead + AsyncWrite {
     fn remote_addr(&self) -> Option<SocketAddr>;
+
+    fn tls_peer_certificates(&self) -> Option<Vec<Vec<u8>>>;
 }
 
 impl Transport for AddrStream {
     fn remote_addr(&self) -> Option<SocketAddr> {
         Some(self.remote_addr())
+    }
+
+    fn tls_peer_certificates(&self) -> Option<Vec<Vec<u8>>> {
+        None
     }
 }
 
@@ -48,6 +54,10 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for LiftIo<T> {
 
 impl<T: AsyncRead + AsyncWrite + Unpin> Transport for LiftIo<T> {
     fn remote_addr(&self) -> Option<SocketAddr> {
+        None
+    }
+
+    fn tls_peer_certificates(&self) -> Option<Vec<Vec<u8>>> {
         None
     }
 }


### PR DESCRIPTION
Returns the tls certificate chain from the connection, if the transport
type is using tls and has certificates
closes #227
there's an issue with this though, if we want to address #56 implementing `Service<T>` gets worse due to having  to pass `Request`, `remote_address`, and `tls_peer_certificates` to `Service::call()`