### PR TITLE
add warp::temporary_redirect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub use self::filters::{
 #[doc(hidden)]
 pub use self::filters::ws::ws;
 #[doc(hidden)]
-pub use self::redirect::{redirect, temporary_redirect};
+pub use self::redirect::redirect;
 #[doc(hidden)]
 #[allow(deprecated)]
 pub use self::reject::{reject, Rejection};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,16 +145,16 @@ pub use self::filters::{
 #[doc(hidden)]
 pub use self::filters::ws::ws;
 #[doc(hidden)]
-pub use self::redirect::redirect;
+pub use self::redirect::{redirect, temporary_redirect};
 #[doc(hidden)]
 #[allow(deprecated)]
 pub use self::reject::{reject, Rejection};
 #[doc(hidden)]
 pub use self::reply::{reply, Reply};
 pub use self::server::{serve, Server};
-pub use hyper::rt::spawn;
 #[doc(hidden)]
 pub use http;
+pub use hyper::rt::spawn;
 
 #[doc(hidden)]
 pub use bytes::Buf;

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -28,6 +28,27 @@ pub fn redirect(uri: impl AsLocation) -> impl Reply {
     )
 }
 
+/// A simple `307` temporary redirect to a different location.
+///
+/// # Example
+///
+/// ```
+/// use warp::{http::Uri, Filter};
+///
+/// let route = warp::path("v1")
+///     .map(|| {
+///         warp::temporary_redirect(Uri::from_static("/v2"))
+///     });
+/// ```
+///
+pub fn temporary_redirect(uri: impl AsLocation) -> impl Reply {
+    reply::with_header(
+        StatusCode::TEMPORARY_REDIRECT,
+        header::LOCATION,
+        uri.header_value(),
+    )
+}
+
 mod sealed {
     use bytes::Bytes;
     use http::{header::HeaderValue, Uri};

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -37,11 +37,10 @@ pub fn redirect(uri: impl AsLocation) -> impl Reply {
 ///
 /// let route = warp::path("v1")
 ///     .map(|| {
-///         warp::temporary_redirect(Uri::from_static("/v2"))
+///         warp::redirect::temporary(Uri::from_static("/v2"))
 ///     });
 /// ```
-///
-pub fn temporary_redirect(uri: impl AsLocation) -> impl Reply {
+pub fn temporary(uri: impl AsLocation) -> impl Reply {
     reply::with_header(
         StatusCode::TEMPORARY_REDIRECT,
         header::LOCATION,


### PR DESCRIPTION
This just adds `warp::temporary_redirect` (307) alongside `warp::redirect` (301). Found this utility function helpful and figured others might need it too. 

In my case I was implementing oauth login and needed code to run in the handler before every redirect. A permanent redirect (301) gets cached in most browsers so `warp::redirect` wouldn't work because the server would never even get called on subsequent login attempts.