### PR TITLE
[Draft] tower_service::Service <-> warp::Filter interop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ rustls = { version = "0.16", optional = true }
 tungstenite = { default-features = false, version = "0.9", optional = true }
 urlencoding = "1.0.0"
 pin-project = "0.4.5"
+tower-service = "0.3.0-alpha.2"
 
 [dev-dependencies]
 pretty_env_logger = "0.3"

--- a/examples/hyper.rs
+++ b/examples/hyper.rs
@@ -1,0 +1,26 @@
+extern crate warp;
+extern crate hyper;
+
+use warp::Filter;
+use hyper::Server;
+use hyper::service::{make_service_fn, service_fn};
+use tower_service::Service;
+
+#[tokio::main]
+async fn main() {
+    let addr = ([0, 0, 0, 0], 3030).into();
+
+    let routes = warp::any().map(|| "hello world");
+
+    let make_service = make_service_fn(move |_| {
+            let routes = routes.clone();
+            futures::future::ok::<_, hyper::Error>(service_fn(move |req| routes.into_service().call(req)))
+        });
+
+    let server = Server::bind(&addr)
+        .serve(make_service);
+
+    if let Err(e) = server.await {
+        eprintln!("server error: {}", e);
+    }
+}

--- a/examples/tower_service.rs
+++ b/examples/tower_service.rs
@@ -1,0 +1,40 @@
+extern crate warp;
+extern crate hyper;
+
+use std::task::{Context, Poll};
+use std::pin::Pin;
+use std::future::Future;
+use warp::{Response, Request};
+use warp::reject::Reject;
+use tower_service::Service;
+
+#[derive(Clone)]
+struct TowerService;
+
+#[derive(Debug)]
+struct ServiceError;
+impl Reject for ServiceError {}
+
+impl Service<Request> for TowerService {
+    type Response = Response;
+    type Error = ServiceError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request) -> Self::Future {
+        // Create the HTTP response
+        let resp = Response::new("hello world".into());
+
+        // Return the response as an immediate future
+        Box::pin(futures::future::ok(resp))
+    }
+}
+
+#[tokio::main]
+async fn main() {
+
+    warp::serve_service(TowerService).run(([127, 0, 0, 1], 3030)).await;
+}

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -31,7 +31,7 @@ use self::recover::Recover;
 use self::unify::Unify;
 use self::untuple_one::UntupleOne;
 pub(crate) use self::wrap::{Wrap, WrapSealed};
-pub use service::FilteredService;
+pub use service::{FilteredService, TowerService};
 
 // A crate-private base trait, allowing the actual `filter` method to change
 // signatures without it being a breaking change.
@@ -404,12 +404,11 @@ pub trait Filter: FilterBase {
     /// # Example
     ///
     /// ```
-    /// # extern crate warp;
-    /// # extern crate tower_service;
     /// use warp::Filter;
     /// use tower_service::Service as TowerService;
+    /// use warp::Request;
     ///
-    /// fn tower_service() -> impl TowerService {
+    /// fn tower_service() -> impl TowerService<Request> {
     ///   warp::any().map(|| "ok").into_service()
     /// }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,3 +163,4 @@ pub use futures::{Future, Sink, Stream};
 #[doc(hidden)]
 
 pub(crate) type Request = http::Request<hyper::Body>;
+pub(crate) type Response = hyper::Response<hyper::Body>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,10 +151,10 @@ pub use self::redirect::redirect;
 pub use self::reject::{reject, Rejection};
 #[doc(hidden)]
 pub use self::reply::{reply, Reply};
-pub use self::server::{serve, Server};
+pub use self::server::{serve, serve_service, Server};
+pub use hyper::rt::spawn;
 #[doc(hidden)]
 pub use http;
-pub use hyper::rt::spawn;
 
 #[doc(hidden)]
 pub use bytes::Buf;
@@ -162,5 +162,8 @@ pub use bytes::Buf;
 pub use futures::{Future, Sink, Stream};
 #[doc(hidden)]
 
-pub(crate) type Request = http::Request<hyper::Body>;
-pub(crate) type Response = hyper::Response<hyper::Body>;
+///type alias for a Hyper Request
+pub type Request = http::Request<hyper::Body>;
+
+///type alias for a Hyper Request
+pub type Response = hyper::Response<hyper::Body>;

--- a/src/test.rs
+++ b/src/test.rs
@@ -452,7 +452,7 @@ impl WsBuilder {
     /// ```
     pub async fn handshake<F>(self, f: F) -> Result<WsClient, WsError>
     where
-        F: Filter + Send + Sync + 'static,
+        F: Filter + Send + Sync + 'static + Clone,
         F::Extract: Reply + Send,
         F::Error: IsReject + Send,
     {

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -130,7 +130,7 @@ async fn limit_message_size() {
     assert!(client.recv().await.is_err());
 }
 
-fn ws_echo() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> {
+fn ws_echo() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::ws().map(|ws: warp::ws::Ws| {
         ws.on_upgrade(|websocket| {
             // Just echo all messages back...


### PR DESCRIPTION
I continued the work started on #70 to try and make `tower_service::Service`'s run on warp and the ability to run `warp::Filter`'s as a service on Hyper.
### Notes
 
- to be able to call `tower_service::Service::call(&mut self, req: Request)` I had to remove the `Arc` usage and `Clone` to the trait bounds, I benchmarked and results seemed similar benchmarking the hello world example with `--release`:

(with Arc)
```
$ wrk -t4 -c1000 -d30s --latency http://127.0.0.1:3030
Running 30s test @ http://127.0.0.1:3030
  4 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.34ms    3.79ms  82.56ms   87.93%
    Req/Sec    12.71k     3.47k   22.53k    65.86%
  Latency Distribution
     50%    3.19ms
     75%    5.16ms
     90%    8.69ms
     99%   18.67ms
  1519131 requests in 30.06s, 188.34MB read
  Socket errors: connect 751, read 114, write 2, timeout 0
Requests/sec:  50530.67
Transfer/sec:      6.26MB
```
(with Clone)
```
$ wrk -t4 -c1000 -d30s --latency http://127.0.0.1:3030
Running 30s test @ http://127.0.0.1:3030
  4 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.31ms    2.95ms  41.62ms   81.27%
    Req/Sec    12.68k     3.62k   22.61k    60.70%
  Latency Distribution
     50%    3.57ms
     75%    5.20ms
     90%    8.03ms
     99%   14.95ms
  1517745 requests in 30.08s, 188.17MB read
  Socket errors: connect 751, read 102, write 42, timeout 0
Requests/sec:  50463.45
Transfer/sec:      6.26MB
```

- I looked into #222 and since the `WarpService` trait already existed and is also passing the `remote_addr` extra argument, so I impled `WarpService` for T: `tower_service::Service `, when a `Service` is called via warp `remote_addr`(or other future arguments's, see https://github.com/seanmonstar/warp/pull/318) is discarded

- impl `WarpService` for T: `tower_service::Service` requires `tower_service::Service::Error : warp::Reject`  that seemed to be the simplest way to then integrate Service errors with warp's logging and error handling, should another error be used/should `Reject` be impled for T? 

- I think there still needs to be developed a way to compose `warp::Filter`'s with `tower_service::Service`'s, but maybe that could be done after closing the interop API?  