### PR TITLE
Re-export hyper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,8 @@ pub use self::reply::{reply, Reply};
 pub use self::server::{serve, Server};
 #[doc(hidden)]
 pub use http;
+#[doc(hidden)]
+pub use hyper;
 pub use hyper::rt::spawn;
 
 #[doc(hidden)]


### PR DESCRIPTION
mildly annoying to have to also depend on hyper for hyper::Body; already re-exports http, so might as well do both