### PR TITLE
Adds example for Unix sockets. Resolves #282.

### DIFF
--- a/examples/unix_socket.rs
+++ b/examples/unix_socket.rs
@@ -1,0 +1,13 @@
+#![deny(warnings)]
+
+use tokio::net::UnixListener;
+
+#[tokio::main]
+async fn main() {
+    pretty_env_logger::init();
+
+    let incoming = UnixListener::bind("/tmp/warp.sock").unwrap().incoming();
+    warp::serve(warp::fs::dir("examples/dir"))
+        .run_incoming(incoming)
+        .await;
+}


### PR DESCRIPTION
Once we're on Tokio 0.2.0, this example also needs the `uds` feature on Tokio.