### PR TITLE
Update to hyper 0.13/tokio 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ features = ["tls"]
 bytes = "0.5.2"
 futures = "0.3"
 futures-util = "0.3"
-headers = { git = "https://github.com/hyperium/headers.git" }
+headers = "0.3"
 http = "0.2"
 hyper = { version = "0.13", features = ["stream"] }
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ publish = false # while in pre-0.2.x alpha dev
 features = ["tls"]
 
 [dependencies]
-bytes = "0.5.2"
+bytes = "0.5"
 futures = "0.3"
 futures-util = "0.3"
 headers = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ publish = false # while in pre-0.2.x alpha dev
 features = ["tls"]
 
 [dependencies]
-bytes = "0.4.8"
-futures-preview = "0.3.0-alpha.19"
-futures-util-preview = "0.3.0-alpha.19"
-headers = "0.2"
-http = "0.1"
-hyper = { version = "=0.13.0-alpha.4", features = ["unstable-stream"] }
+bytes = "0.5.2"
+futures = "0.3"
+futures-util = "0.3"
+headers = { git = "https://github.com/hyperium/headers.git" }
+http = "0.2"
+hyper = { version = "0.13", features = ["stream"] }
 log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.0"
@@ -33,8 +33,8 @@ scoped-tls = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.6"
-tokio = "0.2.0-alpha.6"
-tokio-executor = "=0.2.0-alpha.6"
+tokio = { version = "0.2", features = ["blocking", "fs", "macros", "stream", "sync", "time"] }
+tower-service = "0.3"
 rustls = { version = "0.16", optional = true }
 # tls is enabled by default, we don't want that yet
 tungstenite = { default-features = false, version = "0.9", optional = true }
@@ -66,6 +66,10 @@ required-features = ["multipart"]
 [[test]]
 name = "ws"
 required-features = ["websocket"]
+
+[[example]]
+name = "unix_socket"
+required-features = ["tokio/uds"]
 
 [[example]]
 name = "websockets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ scoped-tls = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.6"
-tokio = { version = "0.2", features = ["blocking", "fs", "macros", "stream", "sync", "time"] }
+tokio = { version = "0.2", features = ["blocking", "fs", "macros", "rt-threaded", "stream", "sync", "time"] }
 tower-service = "0.3"
 rustls = { version = "0.16", optional = true }
 # tls is enabled by default, we don't want that yet

--- a/examples/futures.rs
+++ b/examples/futures.rs
@@ -1,8 +1,8 @@
 #![deny(warnings)]
 
 use std::str::FromStr;
-use std::time::{Duration, Instant};
-use tokio::timer::delay;
+use std::time::Duration;
+use tokio::time::delay_for;
 use warp::Filter;
 
 /// A newtype to enforce our maximum allowed seconds.
@@ -27,7 +27,7 @@ async fn main() {
     let routes = warp::path::param()
         // and_then create a `Future` that will simply wait N seconds...
         .and_then(|Seconds(seconds): Seconds| async move {
-            delay(Instant::now() + Duration::from_secs(seconds)).await;
+            delay_for(Duration::from_secs(seconds)).await;
             Ok::<String, warp::Rejection>(format!("I waited {} seconds!", seconds))
         });
 

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 use std::convert::Infallible;
-use tokio::{clock::now, timer::Interval};
+use tokio::time::interval;
 use futures::StreamExt;
 use warp::{Filter, sse::ServerSentEvent};
 
@@ -18,7 +18,7 @@ async fn main() {
         .map(|sse: warp::sse::Sse| {
             let mut counter: u64 = 0;
             // create server event source
-            let event_stream = Interval::new(now(), Duration::from_secs(1)).map(move |_| {
+            let event_stream = interval(Duration::from_secs(1)).map(move |_| {
                 counter += 1;
                 sse_counter(counter)
             });

--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -86,9 +86,9 @@ fn user_connected(
 
     // Use an unbounded channel to handle buffering and flushing of messages
     // to the event source...
-    let (mut tx, rx) = mpsc::unbounded_channel();
+    let (tx, rx) = mpsc::unbounded_channel();
 
-    match tx.try_send(Message::UserId(my_id)) {
+    match tx.send(Message::UserId(my_id)) {
         Ok(()) => (),
         Err(_disconnected) => {
             // The tx is disconnected, our `user_disconnected` code
@@ -109,7 +109,7 @@ fn user_connected(
 
     // When `drx` will dropped then `dtx` will be canceled.
     // We can track it to make sure when the user leaves chat.
-    warp::spawn(async move {
+    tokio::task::spawn(async move {
         dtx.closed().await;
         drx.close();
         user_disconnected(my_id, &users2);
@@ -131,7 +131,7 @@ fn user_message(my_id: usize, msg: String, users: &Users) {
     // appears to have disconnected.
     for (&uid, tx) in users.lock().unwrap().iter_mut() {
         if my_id != uid {
-            match tx.try_send(Message::Reply(new_msg.clone())) {
+            match tx.send(Message::Reply(new_msg.clone())) {
                 Ok(()) => (),
                 Err(_disconnected) => {
                     // The tx is disconnected, our `user_disconnected` code

--- a/examples/websockets_chat.rs
+++ b/examples/websockets_chat.rs
@@ -59,7 +59,7 @@ fn user_connected(ws: WebSocket, users: Users) -> impl Future<Output = Result<()
     // Use an unbounded channel to handle buffering and flushing of messages
     // to the websocket...
     let (tx, rx) = mpsc::unbounded_channel();
-    warp::spawn(
+    tokio::task::spawn(
         rx
             .forward(user_ws_tx)
             .map(|result| {
@@ -113,7 +113,7 @@ fn user_message(my_id: usize, msg: Message, users: &Users) {
     // appears to have disconnected.
     for (&uid, tx) in users.lock().unwrap().iter_mut() {
         if my_id != uid {
-            match tx.try_send(Ok(Message::text(new_msg.clone()))) {
+            match tx.send(Ok(Message::text(new_msg.clone()))) {
                 Ok(()) => (),
                 Err(_disconnected) => {
                     // The tx is disconnected, our `user_disconnected` code

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -6,7 +6,6 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::future::Future;
 
 use bytes::Buf;
 use futures::{future, ready, TryFuture, TryStreamExt, Stream};

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -7,11 +7,11 @@ use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use bytes::Buf;
-use futures::{future, ready, TryFuture, TryStreamExt, Stream};
+use bytes::{Bytes, Buf};
+use futures::{future, ready, TryFutureExt, Stream};
 use headers::ContentLength;
 use http::header::CONTENT_TYPE;
-use hyper::{Body, Chunk};
+use hyper::Body;
 use mime;
 use serde::de::DeserializeOwned;
 use serde_json;
@@ -104,9 +104,14 @@ pub fn stream() -> impl Filter<Extract = (BodyStream,), Error = Rejection> + Cop
 ///     });
 /// ```
 pub fn concat() -> impl Filter<Extract = (FullBody,), Error = Rejection> + Copy {
-    body().and_then(|body: ::hyper::Body| Concat {
-        fut: body.try_concat(),
-    })
+    body().and_then(|body: ::hyper::Body|
+        hyper::body::to_bytes(body)
+            .map_ok(|bytes| FullBody { bytes })
+            .map_err(|err| {
+                log::debug!("concat error: {}", err);
+                reject::known(BodyReadError(err))
+            })
+    )
 }
 
 // Require the `content-type` header to be this type (or, if there's no `content-type`
@@ -170,7 +175,7 @@ pub fn json<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error =
     is_content_type(mime::APPLICATION, mime::JSON)
         .and(concat())
         .and_then(|buf: FullBody| {
-            future::ready(serde_json::from_slice(&buf.chunk).map_err(|err| {
+            future::ready(serde_json::from_slice(&buf.bytes).map_err(|err| {
                 log::debug!("request json body error: {}", err);
                 reject::known(BodyDeserializeError { cause: err.into() })
             }))
@@ -205,7 +210,7 @@ pub fn form<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error =
     is_content_type(mime::APPLICATION, mime::WWW_FORM_URLENCODED)
         .and(concat())
         .and_then(|buf: FullBody| {
-            future::ready(serde_urlencoded::from_bytes(&buf.chunk).map_err(|err| {
+            future::ready(serde_urlencoded::from_bytes(&buf.bytes).map_err(|err| {
                 log::debug!("request form body error: {}", err);
                 reject::known(BodyDeserializeError { cause: err.into() })
             }))
@@ -222,49 +227,30 @@ pub struct FullBody {
     // By concealing how a full body (concat()) is represented, this can be
     // improved to be a `Vec<Chunk>` or similar, thus reducing copies required
     // in the common case.
-    chunk: Chunk,
+    bytes: Bytes,
 }
 
 impl FullBody {
     #[cfg(feature = "multipart")]
-    pub(super) fn into_chunk(self) -> Chunk {
-        self.chunk
+    pub(super) fn into_bytes(self) -> Bytes {
+        self.bytes
     }
 }
 
 impl Buf for FullBody {
     #[inline]
     fn remaining(&self) -> usize {
-        self.chunk.remaining()
+        self.bytes.remaining()
     }
 
     #[inline]
     fn bytes(&self) -> &[u8] {
-        self.chunk.bytes()
+        self.bytes.bytes()
     }
 
     #[inline]
     fn advance(&mut self, cnt: usize) {
-        self.chunk.advance(cnt);
-    }
-}
-
-#[allow(missing_debug_implementations)]
-struct Concat {
-    fut: futures_util::try_stream::TryConcat<Body>,
-}
-
-impl Future for Concat {
-    type Output = Result<FullBody, Rejection>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        match ready!(Pin::new(&mut self.get_mut().fut).try_poll(cx)) {
-            Ok(chunk) => Poll::Ready(Ok(FullBody { chunk })),
-            Err(err) => {
-                log::debug!("concat error: {}", err);
-                Poll::Ready(Err(reject::known(BodyReadError(err))))
-            }
-        }
+        self.bytes.advance(cnt);
     }
 }
 
@@ -279,7 +265,7 @@ impl Stream for BodyStream {
     type Item = Result<StreamBuf, crate::Error>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        let opt_item: Option<Result<Chunk, hyper::Error>> = ready!(Pin::new(&mut self.get_mut().body).poll_next(cx));
+        let opt_item: Option<Result<Bytes, hyper::Error>> = ready!(Pin::new(&mut self.get_mut().body).poll_next(cx));
 
         match opt_item {
             None =>  Poll::Ready(None),
@@ -304,7 +290,7 @@ impl fmt::Debug for BodyStream {
 ///
 /// Yielded by a `BodyStream`.
 pub struct StreamBuf {
-    chunk: Chunk,
+    chunk: Bytes,
 }
 
 impl Buf for StreamBuf {

--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -1,6 +1,7 @@
 //! CORS Filters
 
 use std::collections::HashSet;
+use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::sync::Arc;
 
@@ -10,7 +11,6 @@ use headers::{
 use http::{
     self,
     header::{self, HeaderName, HeaderValue},
-    HttpTryFrom,
 };
 
 use crate::filter::{Filter, WrapSealed};
@@ -80,9 +80,9 @@ impl Cors {
     /// Panics if the provided argument is not a valid `http::Method`.
     pub fn allow_method<M>(mut self, method: M) -> Self
     where
-        http::Method: HttpTryFrom<M>,
+        http::Method: TryFrom<M>,
     {
-        let method = match HttpTryFrom::try_from(method) {
+        let method = match TryFrom::try_from(method) {
             Ok(m) => m,
             Err(_) => panic!("illegal Method"),
         };
@@ -98,9 +98,9 @@ impl Cors {
     pub fn allow_methods<I>(mut self, methods: I) -> Self
     where
         I: IntoIterator,
-        http::Method: HttpTryFrom<I::Item>,
+        http::Method: TryFrom<I::Item>,
     {
-        let iter = methods.into_iter().map(|m| match HttpTryFrom::try_from(m) {
+        let iter = methods.into_iter().map(|m| match TryFrom::try_from(m) {
             Ok(m) => m,
             Err(_) => panic!("illegal Method"),
         });
@@ -115,9 +115,9 @@ impl Cors {
     /// Panics if the provided argument is not a valid `http::header::HeaderName`.
     pub fn allow_header<H>(mut self, header: H) -> Self
     where
-        HeaderName: HttpTryFrom<H>,
+        HeaderName: TryFrom<H>,
     {
-        let header = match HttpTryFrom::try_from(header) {
+        let header = match TryFrom::try_from(header) {
             Ok(m) => m,
             Err(_) => panic!("illegal Header"),
         };
@@ -133,9 +133,9 @@ impl Cors {
     pub fn allow_headers<I>(mut self, headers: I) -> Self
     where
         I: IntoIterator,
-        HeaderName: HttpTryFrom<I::Item>,
+        HeaderName: TryFrom<I::Item>,
     {
-        let iter = headers.into_iter().map(|h| match HttpTryFrom::try_from(h) {
+        let iter = headers.into_iter().map(|h| match TryFrom::try_from(h) {
             Ok(h) => h,
             Err(_) => panic!("illegal Header"),
         });
@@ -150,9 +150,9 @@ impl Cors {
     /// Panics if the provided argument is not a valid `http::header::HeaderName`.
     pub fn expose_header<H>(mut self, header: H) -> Self
     where
-        HeaderName: HttpTryFrom<H>,
+        HeaderName: TryFrom<H>,
     {
-        let header = match HttpTryFrom::try_from(header) {
+        let header = match TryFrom::try_from(header) {
             Ok(m) => m,
             Err(_) => panic!("illegal Header"),
         };
@@ -168,9 +168,9 @@ impl Cors {
     pub fn expose_headers<I>(mut self, headers: I) -> Self
     where
         I: IntoIterator,
-        HeaderName: HttpTryFrom<I::Item>,
+        HeaderName: TryFrom<I::Item>,
     {
-        let iter = headers.into_iter().map(|h| match HttpTryFrom::try_from(h) {
+        let iter = headers.into_iter().map(|h| match TryFrom::try_from(h) {
             Ok(h) => h,
             Err(_) => panic!("illegal Header"),
         });

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -107,7 +107,7 @@ fn path_from_tail(
             future::ready(sanitize_path(base.as_ref(), tail.as_str()))
                 .and_then(|mut buf| async {
                     let clone_buf = buf.clone();
-                    let is_dir = tokio_executor::blocking::run(move || clone_buf.is_dir()).await;
+                    let is_dir = tokio::task::spawn_blocking(move || clone_buf.is_dir()).await.expect("FIXME");
                     if is_dir {
                         log::debug!("dir: appending index.html to directory path");
                         buf.push("index.html");

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -106,8 +106,7 @@ fn path_from_tail(
         .and_then(move |tail: crate::path::Tail| {
             future::ready(sanitize_path(base.as_ref(), tail.as_str()))
                 .and_then(|mut buf| async {
-                    let clone_buf = buf.clone();
-                    let is_dir = tokio::task::spawn_blocking(move || clone_buf.is_dir()).await.expect("FIXME");
+                    let is_dir = tokio::task::block_in_place(|| buf.is_dir());
                     if is_dir {
                         log::debug!("dir: appending index.html to directory path");
                         buf.push("index.html");

--- a/src/filters/log.rs
+++ b/src/filters/log.rs
@@ -5,7 +5,6 @@ use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
 use http::{self, header, StatusCode};
-use tokio::clock;
 
 use crate::filter::{Filter, WrapSealed};
 use crate::reject::IsReject;
@@ -153,7 +152,7 @@ impl<'a> Info<'a> {
 
     /// View the `Duration` that elapsed for the request.
     pub fn elapsed(&self) -> Duration {
-        clock::now() - self.start
+        tokio::time::Instant::now().into_std() - self.start
     }
 
     /// View the host of the request
@@ -221,7 +220,7 @@ mod internal {
         type Future = WithLogFuture<FN, F::Future>;
 
         fn filter(&self) -> Self::Future {
-            let started = ::tokio::clock::now();
+            let started = tokio::time::Instant::now().into_std();
             WithLogFuture {
                 log: self.log.clone(),
                 future: self.filter.filter(),

--- a/src/filters/multipart.rs
+++ b/src/filters/multipart.rs
@@ -31,7 +31,7 @@ pub struct FormOptions {
 ///
 /// Extracted with a `warp::multipart::form` filter.
 pub struct FormData {
-    inner: Multipart<Cursor<::hyper::Chunk>>,
+    inner: Multipart<Cursor<::bytes::Bytes>>,
 }
 
 /// A single "part" of a multipart/form-data body.
@@ -86,7 +86,7 @@ impl FilterBase for FormOptions {
             .and(boundary)
             .and(super::body::concat())
             .map(|boundary, body: super::body::FullBody| FormData {
-                inner: Multipart::with_body(Cursor::new(body.into_chunk()), boundary),
+                inner: Multipart::with_body(Cursor::new(body.into_bytes()), boundary),
             });
 
         let fut = filt.filter();

--- a/src/filters/reply.rs
+++ b/src/filters/reply.rs
@@ -19,10 +19,10 @@
 //! Wrapping allows adding in conditional logic *before* the request enters
 //! the inner filter (though the `with::header` wrapper does not).
 
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 use http::header::{HeaderMap, HeaderName, HeaderValue};
-use http::HttpTryFrom;
 
 use self::sealed::{WithDefaultHeader_, WithHeader_, WithHeaders_};
 use crate::filter::{Filter, Map, WrapSealed};
@@ -48,8 +48,10 @@ use crate::reply::Reply;
 /// ```
 pub fn header<K, V>(name: K, value: V) -> WithHeader
 where
-    HeaderName: HttpTryFrom<K>,
-    HeaderValue: HttpTryFrom<V>,
+    HeaderName: TryFrom<K>,
+    <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
+    HeaderValue: TryFrom<V>,
+    <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
 {
     let (name, value) = assert_name_and_value(name, value);
     WithHeader { name, value }
@@ -107,8 +109,10 @@ pub fn headers(headers: HeaderMap) -> WithHeaders {
 /// ```
 pub fn default_header<K, V>(name: K, value: V) -> WithDefaultHeader
 where
-    HeaderName: HttpTryFrom<K>,
-    HeaderValue: HttpTryFrom<V>,
+    HeaderName: TryFrom<K>,
+    <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
+    HeaderValue: TryFrom<V>,
+    <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
 {
     let (name, value) = assert_name_and_value(name, value);
     WithDefaultHeader { name, value }
@@ -175,14 +179,16 @@ where
 
 fn assert_name_and_value<K, V>(name: K, value: V) -> (HeaderName, HeaderValue)
 where
-    HeaderName: HttpTryFrom<K>,
-    HeaderValue: HttpTryFrom<V>,
+    HeaderName: TryFrom<K>,
+    <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
+    HeaderValue: TryFrom<V>,
+    <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
 {
-    let name = <HeaderName as HttpTryFrom<K>>::try_from(name)
+    let name = <HeaderName as TryFrom<K>>::try_from(name)
         .map_err(Into::into)
         .unwrap_or_else(|_| panic!("invalid header name"));
 
-    let value = <HeaderValue as HttpTryFrom<V>>::try_from(value)
+    let value = <HeaderValue as TryFrom<V>>::try_from(value)
         .map_err(Into::into)
         .unwrap_or_else(|_| panic!("invalid header value"));
 
@@ -243,7 +249,6 @@ mod sealed {
             let mut resp = args.0.into_response();
             resp.headers_mut()
                 .entry(&self.with.name)
-                .expect("parsed headername is always valid")
                 .or_insert_with(|| self.with.value.clone());
 
             Reply_(resp)

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -52,7 +52,7 @@ use http::header::{HeaderValue, CACHE_CONTROL, CONTENT_TYPE};
 use hyper::Body;
 use serde::Serialize;
 use serde_json;
-use tokio::{clock::now, timer::{self, Delay}};
+use tokio::time::{self, Delay};
 
 use self::sealed::{
     BoxedServerSentEvent, EitherServerSentEvent, SseError, SseField, SseFormat, SseWrapper,
@@ -508,7 +508,7 @@ impl KeepAlive {
         S::Ok: ServerSentEvent + Send,
         S::Error: StdError + Send + Sync + 'static,
     {
-        let alive_timer = timer::delay(now() + self.max_interval);
+        let alive_timer = time::delay_for(self.max_interval);
         SseKeepAlive {
             event_stream,
             comment_text: self.comment_text,
@@ -545,7 +545,7 @@ where
     let max_interval = keep_interval
         .into()
         .unwrap_or_else(|| Duration::from_secs(15));
-    let alive_timer = timer::delay(now() + max_interval);
+    let alive_timer = time::delay_for(max_interval);
     SseKeepAlive {
         event_stream,
         comment_text: Cow::Borrowed(""),
@@ -568,7 +568,7 @@ where
 /// use std::time::Duration;
 /// use std::convert::Infallible;
 /// use futures::StreamExt;
-/// use tokio::{clock::now, timer::Interval};
+/// use tokio::time::interval;
 /// use warp::{Filter, Stream, sse::ServerSentEvent};
 ///
 /// // create server-sent event
@@ -581,7 +581,7 @@ where
 ///         .and(warp::sse())
 ///         .map(|sse: warp::sse::Sse| {
 ///             let mut counter: u64 = 0;
-///             let event_stream = Interval::new(now(), Duration::from_secs(15)).map(move |_| {
+///             let event_stream = interval(Duration::from_secs(15)).map(move |_| {
 ///                 counter += 1;
 ///                 sse_counter(counter)
 ///             });
@@ -618,7 +618,7 @@ where
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(_) => {
                     // restart timer
-                    pin.alive_timer.reset(now() + *pin.max_interval);
+                    pin.alive_timer.reset(tokio::time::Instant::now() + *pin.max_interval);
                     let comment_str = pin.comment_text.clone();
                     Poll::Ready(Some(Ok(EitherServerSentEvent::B(SseComment(
                         comment_str,
@@ -627,7 +627,7 @@ where
             },
             Poll::Ready(Some(Ok(event))) => {
                 // restart timer
-                pin.alive_timer.reset(now() + *pin.max_interval);
+                pin.alive_timer.reset(tokio::time::Instant::now() + *pin.max_interval);
                 Poll::Ready(Some(Ok(EitherServerSentEvent::A(event))))
             },
             Poll::Ready(None) => Poll::Ready(None),

--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -143,7 +143,7 @@ where
                    log::debug!("ws upgrade error: {}", err);
                 }
             });
-        ::hyper::rt::spawn(fut);
+        ::tokio::task::spawn(fut);
 
         let mut res = http::Response::default();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,6 @@ pub use self::server::{serve, Server};
 pub use http;
 #[doc(hidden)]
 pub use hyper;
-pub use hyper::rt::spawn;
 
 #[doc(hidden)]
 pub use bytes::Buf;

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -64,7 +64,7 @@ mod sealed {
     impl Sealed for Uri {
         fn header_value(self) -> HeaderValue {
             let bytes = Bytes::from(self.to_string());
-            HeaderValue::from_shared(bytes).expect("Uri is a valid HeaderValue")
+            HeaderValue::from_maybe_shared(bytes).expect("Uri is a valid HeaderValue")
         }
     }
 }

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -770,13 +770,9 @@ mod tests {
     }
 
     async fn response_body_string(resp: crate::reply::Response) -> String {
-        use futures::TryStreamExt;
-
         let (_, body) = resp.into_parts();
-        match body.try_concat().await {
-            Ok(chunk) => String::from_utf8_lossy(&chunk).to_string(),
-            err => unreachable!("{:?}", err),
-        }
+        let body_bytes = hyper::body::to_bytes(body).await.expect("failed concat");
+        String::from_utf8_lossy(&body_bytes).to_string()
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -272,7 +272,7 @@ where
     ///     });
     ///
     /// // Spawn the server into a runtime
-    /// warp::spawn(server);
+    /// tokio::task::spawn(server);
     ///
     /// // Later, start the shutdown...
     /// let _ = tx.send(());

--- a/src/server.rs
+++ b/src/server.rs
@@ -129,7 +129,6 @@ where
     pub async fn run(self, addr: impl Into<SocketAddr> + 'static) {
         let (addr, fut) = self.bind_ephemeral(addr);
 
-
         log::info!("warp drive engaged: listening on http://{}", addr);
 
         fut.await;
@@ -141,7 +140,7 @@ where
     /// This can be used for Unix Domain Sockets, or TLS, etc.
     pub async fn run_incoming<I>(self, incoming: I)
     where
-        I: TryStream + Send + 'static,
+        I: TryStream + Send,
         I::Ok: AsyncRead + AsyncWrite + Send + 'static + Unpin,
         I::Error: Into<Box<dyn StdError + Send + Sync>>,
     {
@@ -150,7 +149,7 @@ where
 
     async fn run_incoming2<I>(self, incoming: I)
     where
-        I: TryStream + Send + 'static,
+        I: TryStream + Send,
         I::Ok: Transport + Send + 'static + Unpin,
         I::Error: Into<Box<dyn StdError + Send + Sync>>,
     {
@@ -311,7 +310,7 @@ where
 
     async fn serve_incoming2<I>(self, incoming: I)
     where
-        I: TryStream + Send + 'static,
+        I: TryStream + Send,
         I::Ok: Transport + Send + 'static + Unpin,
         I::Error: Into<Box<dyn StdError + Send + Sync>>,
     {

--- a/src/test.rs
+++ b/src/test.rs
@@ -348,7 +348,7 @@ impl RequestBuilder {
                     }
                 };
                 let (parts, body) = res.into_parts();
-                body.try_concat()
+                hyper::body::to_bytes(body)
                     .map_ok(|chunk| Response::from_parts(parts, chunk.into()))
             });
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -79,6 +79,7 @@
 //!     assert_eq!(res.body(), "Sum is 3");
 //! }
 //! ```
+use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::fmt;
 use std::net::SocketAddr;
@@ -96,7 +97,7 @@ use tokio::{
 };
 use http::{
     header::{HeaderName, HeaderValue},
-    HttpTryFrom, Response,
+    Response,
 };
 use serde::Serialize;
 use serde_json;
@@ -213,13 +214,13 @@ impl RequestBuilder {
     /// `HeaderName` and `HeaderValue`.
     pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
-        HeaderName: HttpTryFrom<K>,
-        HeaderValue: HttpTryFrom<V>,
+        HeaderName: TryFrom<K>,
+        HeaderValue: TryFrom<V>,
     {
-        let name: HeaderName = HttpTryFrom::try_from(key)
+        let name: HeaderName = TryFrom::try_from(key)
             .map_err(|_| ())
             .expect("invalid header name");
-        let value = HttpTryFrom::try_from(value)
+        let value = TryFrom::try_from(value)
             .map_err(|_| ())
             .expect("invalid header value");
         self.req.headers_mut().insert(name, value);
@@ -418,8 +419,8 @@ impl WsBuilder {
     /// `HeaderName` and `HeaderValue`.
     pub fn header<K, V>(self, key: K, value: V) -> Self
     where
-        HeaderName: HttpTryFrom<K>,
-        HeaderValue: HttpTryFrom<V>,
+        HeaderName: TryFrom<K>,
+        HeaderValue: TryFrom<V>,
     {
         WsBuilder {
             req: self.req.header(key, value),

--- a/src/test.rs
+++ b/src/test.rs
@@ -87,7 +87,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use bytes::Bytes;
-use futures::{future, FutureExt, TryFutureExt, TryStreamExt};
+use futures::{future, FutureExt, TryFutureExt};
 #[cfg(feature = "websocket")]
 use futures::{SinkExt, StreamExt};
 #[cfg(feature = "websocket")]

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -20,52 +20,62 @@ async fn file() {
     assert_eq!(res.body(), &*contents);
 }
 
-#[tokio::test]
+#[tokio::test(threaded_scheduler)]
 async fn dir() {
     let _ = pretty_env_logger::try_init();
 
-    let file = warp::fs::dir("examples");
+    // https://github.com/tokio-rs/tokio/issues/1532
+    tokio::spawn(async {
+        let file = warp::fs::dir("examples");
 
-    let req = warp::test::request().path("/todos.rs");
-    let res = req.reply(&file).await;
+        let req = warp::test::request().path("/todos.rs");
 
-    assert_eq!(res.status(), 200);
+        let res = req.reply(&file).await;
 
-    let contents = fs::read("examples/todos.rs").expect("fs::read");
-    assert_eq!(res.headers()["content-length"], contents.len().to_string());
-    assert_eq!(res.headers()["content-type"], "text/x-rust");
-    assert_eq!(res.headers()["accept-ranges"], "bytes");
+        assert_eq!(res.status(), 200);
 
-    assert_eq!(res.body(), &*contents);
+        let contents = fs::read("examples/todos.rs").expect("fs::read");
+        assert_eq!(res.headers()["content-length"], contents.len().to_string());
+        assert_eq!(res.headers()["content-type"], "text/x-rust");
+        assert_eq!(res.headers()["accept-ranges"], "bytes");
+
+        assert_eq!(res.body(), &*contents);
+    }).await.expect("spawn failed");
 }
 
-#[tokio::test]
+#[tokio::test(threaded_scheduler)]
 async fn dir_encoded() {
     let _ = pretty_env_logger::try_init();
 
-    let file = warp::fs::dir("examples");
+    // https://github.com/tokio-rs/tokio/issues/1532
+    tokio::spawn(async {
+        let file = warp::fs::dir("examples");
 
-    let req = warp::test::request().path("/todos%2ers");
-    let res = req.reply(&file).await;
+        let req = warp::test::request().path("/todos%2ers");
+        let res = req.reply(&file).await;
 
-    assert_eq!(res.status(), 200);
+        assert_eq!(res.status(), 200);
 
-    let contents = fs::read("examples/todos.rs").expect("fs::read");
-    assert_eq!(res.headers()["content-length"], contents.len().to_string());
+        let contents = fs::read("examples/todos.rs").expect("fs::read");
+        assert_eq!(res.headers()["content-length"], contents.len().to_string());
 
-    assert_eq!(res.body(), &*contents);
+        assert_eq!(res.body(), &*contents);
+    }).await.expect("spawn failed");
 }
 
-#[tokio::test]
+#[tokio::test(threaded_scheduler)]
 async fn dir_not_found() {
     let _ = pretty_env_logger::try_init();
 
-    let file = warp::fs::dir("examples");
+    // https://github.com/tokio-rs/tokio/issues/1532
+    tokio::spawn(async {
+        let file = warp::fs::dir("examples");
 
-    let req = warp::test::request().path("/definitely-not-found");
-    let res = req.reply(&file).await;
+        let req = warp::test::request().path("/definitely-not-found");
+        let res = req.reply(&file).await;
 
-    assert_eq!(res.status(), 404);
+        assert_eq!(res.status(), 404);
+    }).await.expect("spawn failed");
 }
 
 #[tokio::test]
@@ -92,20 +102,23 @@ async fn dir_bad_encoded_path() {
     assert_eq!(res.status(), 404);
 }
 
-#[tokio::test]
+#[tokio::test(threaded_scheduler)]
 async fn dir_fallback_index_on_dir() {
     let _ = pretty_env_logger::try_init();
 
-    let file = warp::fs::dir("examples");
-    let req = warp::test::request().path("/dir");
-    let res = req.reply(&file).await;
-    let contents = fs::read("examples/dir/index.html").expect("fs::read");
-    assert_eq!(res.headers()["content-length"], contents.len().to_string());
-    assert_eq!(res.status(), 200);
-    let req = warp::test::request().path("/dir/");
-    let res = req.reply(&file).await;
-    assert_eq!(res.headers()["content-length"], contents.len().to_string());
-    assert_eq!(res.status(), 200);
+    // https://github.com/tokio-rs/tokio/issues/1532
+    tokio::spawn(async {
+        let file = warp::fs::dir("examples");
+        let req = warp::test::request().path("/dir");
+        let res = req.reply(&file).await;
+        let contents = fs::read("examples/dir/index.html").expect("fs::read");
+        assert_eq!(res.headers()["content-length"], contents.len().to_string());
+        assert_eq!(res.status(), 200);
+        let req = warp::test::request().path("/dir/");
+        let res = req.reply(&file).await;
+        assert_eq!(res.headers()["content-length"], contents.len().to_string());
+        assert_eq!(res.status(), 200);
+    }).await.expect("spawn failed");
 }
 
 #[tokio::test]

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -20,62 +20,52 @@ async fn file() {
     assert_eq!(res.body(), &*contents);
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test]
 async fn dir() {
     let _ = pretty_env_logger::try_init();
 
-    // https://github.com/tokio-rs/tokio/issues/1532
-    tokio::spawn(async {
-        let file = warp::fs::dir("examples");
+    let file = warp::fs::dir("examples");
 
-        let req = warp::test::request().path("/todos.rs");
+    let req = warp::test::request().path("/todos.rs");
+    let res = req.reply(&file).await;
 
-        let res = req.reply(&file).await;
+    assert_eq!(res.status(), 200);
 
-        assert_eq!(res.status(), 200);
+    let contents = fs::read("examples/todos.rs").expect("fs::read");
+    assert_eq!(res.headers()["content-length"], contents.len().to_string());
+    assert_eq!(res.headers()["content-type"], "text/x-rust");
+    assert_eq!(res.headers()["accept-ranges"], "bytes");
 
-        let contents = fs::read("examples/todos.rs").expect("fs::read");
-        assert_eq!(res.headers()["content-length"], contents.len().to_string());
-        assert_eq!(res.headers()["content-type"], "text/x-rust");
-        assert_eq!(res.headers()["accept-ranges"], "bytes");
-
-        assert_eq!(res.body(), &*contents);
-    }).await.expect("spawn failed");
+    assert_eq!(res.body(), &*contents);
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test]
 async fn dir_encoded() {
     let _ = pretty_env_logger::try_init();
 
-    // https://github.com/tokio-rs/tokio/issues/1532
-    tokio::spawn(async {
-        let file = warp::fs::dir("examples");
+    let file = warp::fs::dir("examples");
 
-        let req = warp::test::request().path("/todos%2ers");
-        let res = req.reply(&file).await;
+    let req = warp::test::request().path("/todos%2ers");
+    let res = req.reply(&file).await;
 
-        assert_eq!(res.status(), 200);
+    assert_eq!(res.status(), 200);
 
-        let contents = fs::read("examples/todos.rs").expect("fs::read");
-        assert_eq!(res.headers()["content-length"], contents.len().to_string());
+    let contents = fs::read("examples/todos.rs").expect("fs::read");
+    assert_eq!(res.headers()["content-length"], contents.len().to_string());
 
-        assert_eq!(res.body(), &*contents);
-    }).await.expect("spawn failed");
+    assert_eq!(res.body(), &*contents);
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test]
 async fn dir_not_found() {
     let _ = pretty_env_logger::try_init();
 
-    // https://github.com/tokio-rs/tokio/issues/1532
-    tokio::spawn(async {
-        let file = warp::fs::dir("examples");
+    let file = warp::fs::dir("examples");
 
-        let req = warp::test::request().path("/definitely-not-found");
-        let res = req.reply(&file).await;
+    let req = warp::test::request().path("/definitely-not-found");
+    let res = req.reply(&file).await;
 
-        assert_eq!(res.status(), 404);
-    }).await.expect("spawn failed");
+    assert_eq!(res.status(), 404);
 }
 
 #[tokio::test]
@@ -102,23 +92,20 @@ async fn dir_bad_encoded_path() {
     assert_eq!(res.status(), 404);
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test]
 async fn dir_fallback_index_on_dir() {
     let _ = pretty_env_logger::try_init();
 
-    // https://github.com/tokio-rs/tokio/issues/1532
-    tokio::spawn(async {
-        let file = warp::fs::dir("examples");
-        let req = warp::test::request().path("/dir");
-        let res = req.reply(&file).await;
-        let contents = fs::read("examples/dir/index.html").expect("fs::read");
-        assert_eq!(res.headers()["content-length"], contents.len().to_string());
-        assert_eq!(res.status(), 200);
-        let req = warp::test::request().path("/dir/");
-        let res = req.reply(&file).await;
-        assert_eq!(res.headers()["content-length"], contents.len().to_string());
-        assert_eq!(res.status(), 200);
-    }).await.expect("spawn failed");
+    let file = warp::fs::dir("examples");
+    let req = warp::test::request().path("/dir");
+    let res = req.reply(&file).await;
+    let contents = fs::read("examples/dir/index.html").expect("fs::read");
+    assert_eq!(res.headers()["content-length"], contents.len().to_string());
+    assert_eq!(res.status(), 200);
+    let req = warp::test::request().path("/dir/");
+    let res = req.reply(&file).await;
+    assert_eq!(res.headers()["content-length"], contents.len().to_string());
+    assert_eq!(res.status(), 200);
 }
 
 #[tokio::test]

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -58,7 +58,7 @@ async fn text() {
         .await
         .expect("handshake");
 
-    client.send_text("hello warp");
+    client.send_text("hello warp").await;
 
     let msg = client.recv().await.expect("recv");
     assert_eq!(msg.to_str(), Ok("hello warp"));
@@ -73,7 +73,7 @@ async fn binary() {
         .await
         .expect("handshake");
 
-    client.send(warp::ws::Message::binary(&b"bonk"[..]));
+    client.send(warp::ws::Message::binary(&b"bonk"[..])).await;
     let msg = client.recv().await.expect("recv");
     assert!(msg.is_binary());
     assert_eq!(msg.as_bytes(), b"bonk");
@@ -125,8 +125,8 @@ async fn limit_message_size() {
         .await
         .expect("handshake");
 
-    client.send(warp::ws::Message::binary(vec![0; 1025]));
-    client.send_text("hello warp");
+    client.send(warp::ws::Message::binary(vec![0; 1025])).await;
+    client.send_text("hello warp").await;
     assert!(client.recv().await.is_err());
 }
 


### PR DESCRIPTION
- [x] [headers](https://github.com/hyperium/headers) released with http 0.2

I got rid of a few `'static` bounds from server.rs to get the `unix_socket` example builduing, but it seems like most of the others are unnecessary as well?