### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/examples/handlebars_template.rs
+++ b/examples/handlebars_template.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-use std::error::Error;
 use std::sync::Arc;
 
 use handlebars::Handlebars;
@@ -17,7 +16,7 @@ where
     T: Serialize,
 {
     hbs.render(template.name, &template.value)
-        .unwrap_or_else(|err| err.description().to_owned())
+        .unwrap_or_else(|err| err.to_string())
 }
 
 #[tokio::main]

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -343,9 +343,6 @@ impl fmt::Display for BodyDeserializeError {
 }
 
 impl StdError for BodyDeserializeError {
-    fn description(&self) -> &str {
-        "Request body deserialize error"
-    }
 }
 
 #[derive(Debug)]
@@ -358,9 +355,6 @@ impl ::std::fmt::Display for BodyReadError {
 }
 
 impl StdError for BodyReadError {
-    fn description(&self) -> &str {
-        "Request body read error"
-    }
 }
 
 #[derive(Debug)]
@@ -373,7 +367,4 @@ impl ::std::fmt::Display for BodyConsumedMultipleTimes {
 }
 
 impl StdError for BodyConsumedMultipleTimes {
-    fn description(&self) -> &str {
-        "Request body consumed multiple times"
-    }
 }

--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -293,9 +293,6 @@ impl ::std::fmt::Display for CorsForbidden {
 }
 
 impl StdError for CorsForbidden {
-    fn description(&self) -> &str {
-        "CORS request forbidden"
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/filters/ext.rs
+++ b/src/filters/ext.rs
@@ -48,7 +48,4 @@ impl ::std::fmt::Display for MissingExtension {
 }
 
 impl StdError for MissingExtension {
-    fn description(&self) -> &str {
-        "Missing request extension"
-    }
 }

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -653,9 +653,6 @@ mod sealed {
     }
 
     impl StdError for SseError {
-        fn description(&self) -> &str {
-            "sse error"
-        }
     }
 
     impl Display for SseField {

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -474,9 +474,6 @@ impl ::std::fmt::Display for InvalidQuery {
 }
 
 impl StdError for InvalidQuery {
-    fn description(&self) -> &str {
-        "Invalid query string"
-    }
 }
 
 /// HTTP method not allowed
@@ -490,9 +487,6 @@ impl fmt::Display for MethodNotAllowed {
 }
 
 impl StdError for MethodNotAllowed {
-    fn description(&self) -> &str {
-        "HTTP method not allowed"
-    }
 }
 
 /// A content-length header is required
@@ -506,9 +500,6 @@ impl fmt::Display for LengthRequired {
 }
 
 impl StdError for LengthRequired {
-    fn description(&self) -> &str {
-        "A content-length header is required"
-    }
 }
 
 /// The request payload is too large
@@ -522,9 +513,6 @@ impl fmt::Display for PayloadTooLarge {
 }
 
 impl StdError for PayloadTooLarge {
-    fn description(&self) -> &str {
-        "The request payload is too large"
-    }
 }
 
 /// The request's content-type is not supported
@@ -538,9 +526,6 @@ impl fmt::Display for UnsupportedMediaType {
 }
 
 impl StdError for UnsupportedMediaType {
-    fn description(&self) -> &str {
-        "The request's content-type is not supported"
-    }
 }
 
 /// Missing request header
@@ -554,9 +539,6 @@ impl ::std::fmt::Display for MissingHeader {
 }
 
 impl StdError for MissingHeader {
-    fn description(&self) -> &str {
-        "Missing request header"
-    }
 }
 
 /// Invalid request header
@@ -570,9 +552,6 @@ impl ::std::fmt::Display for InvalidHeader {
 }
 
 impl StdError for InvalidHeader {
-    fn description(&self) -> &str {
-        "Invalid request header"
-    }
 }
 
 /// Missing cookie
@@ -586,9 +565,6 @@ impl ::std::fmt::Display for MissingCookie {
 }
 
 impl StdError for MissingCookie {
-    fn description(&self) -> &str {
-        "Missing request cookie"
-    }
 }
 
 mod sealed {

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -136,14 +136,11 @@ pub(crate) struct ReplyJsonError;
 
 impl fmt::Display for ReplyJsonError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str("warp::reply::json() failed")
     }
 }
 
 impl StdError for ReplyJsonError {
-    fn description(&self) -> &str {
-        "warp::reply::json() failed"
-    }
 }
 
 /// Reply with a body and `content-type` set to `text/html; charset=utf-8`.
@@ -436,9 +433,6 @@ impl ::std::fmt::Display for ReplyHttpError {
 }
 
 impl StdError for ReplyHttpError {
-    fn description(&self) -> &str {
-        "http::Response::builder error"
-    }
 }
 
 impl Reply for String {


### PR DESCRIPTION
Rust is about to deprecate `Error::description` for real, and warp is one of the crates broken by that change.
