### PR TITLE
Change Server-Sent Events API

### DIFF
--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -14,8 +14,8 @@ async fn main() {
     pretty_env_logger::init();
 
     let routes = warp::path("ticks")
-        .and(warp::sse())
-        .map(|sse: warp::sse::Sse| {
+        .and(warp::get())
+        .map(|| {
             let mut counter: u64 = 0;
             // create server event source
             let event_stream = interval(Duration::from_secs(1)).map(move |_| {
@@ -23,7 +23,7 @@ async fn main() {
                 sse_counter(counter)
             });
             // reply using server-sent events
-            sse.reply(event_stream)
+            warp::sse::reply(event_stream)
         });
 
     warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;

--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -55,12 +55,12 @@ async fn main() {
     // GET /chat -> messages stream
     let chat_recv =
         warp::path("chat")
-            .and(warp::sse())
+            .and(warp::get())
             .and(users)
-            .map(|sse: warp::sse::Sse, users| {
+            .map(|users| {
                 // reply using server-sent events
                 let stream = user_connected(users);
-                sse.reply(warp::sse::keep_alive().stream(stream))
+                warp::sse::reply(warp::sse::keep_alive().stream(stream))
             });
 
     // GET / -> index html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,6 @@ pub use self::filters::{
     // query() function
     query::query,
     sse,
-    // sse() function
-    sse::sse,
 };
 // ws() function
 #[cfg(feature = "websocket")]


### PR DESCRIPTION
- Removes the `warp::sse()` filter that yields an `Sse` type.
- Adds `warp::sse::reply` that does the same as what the `Sse::reply`
  method did.