### PR TITLE
Change a few `warp::body` filters

### DIFF
--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -5,7 +5,7 @@ use std::sync::{
     Arc, Mutex,
 };
 use tokio::sync::{mpsc, oneshot};
-use warp::{sse::ServerSentEvent, Buf, Filter};
+use warp::{sse::ServerSentEvent, Filter};
 
 /// Our global unique user id counter.
 static NEXT_USER_ID: AtomicUsize = AtomicUsize::new(1);
@@ -41,8 +41,8 @@ async fn main() {
         .and(warp::post())
         .and(warp::path::param::<usize>())
         .and(warp::body::content_length_limit(500))
-        .and(warp::body::concat().and_then(|body: warp::body::FullBody| async move {
-            std::str::from_utf8(body.bytes())
+        .and(warp::body::bytes().and_then(|body: bytes::Bytes| async move {
+            std::str::from_utf8(&body)
                 .map(String::from)
                 .map_err(|_e| warp::reject::custom(NotUtf8))
         }))

--- a/src/filters/multipart.rs
+++ b/src/filters/multipart.rs
@@ -84,9 +84,9 @@ impl FilterBase for FormOptions {
 
         let filt = super::body::content_length_limit(self.max_length)
             .and(boundary)
-            .and(super::body::concat())
-            .map(|boundary, body: super::body::FullBody| FormData {
-                inner: Multipart::with_body(Cursor::new(body.into_bytes()), boundary),
+            .and(super::body::bytes())
+            .map(|boundary, body| FormData {
+                inner: Multipart::with_body(Cursor::new(body), boundary),
             });
 
         let fut = filt.filter();

--- a/tests/body.rs
+++ b/tests/body.rs
@@ -8,7 +8,7 @@ use bytes::Buf;
 async fn matches() {
     let _ = pretty_env_logger::try_init();
 
-    let concat = warp::body::concat();
+    let concat = warp::body::bytes();
 
     let req = warp::test::request().path("/nothing-matches-me");
 
@@ -26,7 +26,7 @@ async fn matches() {
 async fn server_error_if_taking_body_multiple_times() {
     let _ = pretty_env_logger::try_init();
 
-    let concat = warp::body::concat();
+    let concat = warp::body::bytes();
     let double = concat.and(concat).map(|_, _| warp::reply());
 
     let res = warp::test::request().reply(&double).await;
@@ -188,7 +188,7 @@ async fn stream() {
         .await
         .expect("filter() stream");
 
-    let bufs: Result<Vec<warp::filters::body::StreamBuf>, warp::Error> = body.try_collect().await;
+    let bufs: Result<Vec<_>, warp::Error> = body.try_collect().await;
     let bufs = bufs.unwrap();
 
     assert_eq!(bufs.len(), 1);


### PR DESCRIPTION
- Adds `warp::body::bytes` to concatenate into a single `Bytes`.
- Adds `warp::body::aggregate` to aggregate into some `impl Buf` without
  copying data.
- Changes `warp::body::stream` to yield an `impl Stream`.
- Removes `warp::body::concat`.
- Removes `warp::body::BodyStream`.
- Removes `warp::body::StreamBuf`.
- Removes `warp::body::FullBody`.