### PR TITLE
change handlebars_example return type to text/html so template render…

### DIFF
--- a/examples/handlebars_template.rs
+++ b/examples/handlebars_template.rs
@@ -15,7 +15,8 @@ fn render<T>(template: WithTemplate<T>, hbs: Arc<Handlebars>) -> impl warp::Repl
 where
     T: Serialize,
 {
-    let render = hbs.render(template.name, &template.value)
+    let render = hbs
+        .render(template.name, &template.value)
         .unwrap_or_else(|err| err.to_string());
     warp::reply::html(render)
 }

--- a/examples/handlebars_template.rs
+++ b/examples/handlebars_template.rs
@@ -15,8 +15,7 @@ fn render<T>(template: WithTemplate<T>, hbs: Arc<Handlebars>) -> impl warp::Repl
 where
     T: Serialize,
 {
-    let render = hbs
-        .render(template.name, &template.value)
+    let render = hbs.render(template.name, &template.value)
         .unwrap_or_else(|err| err.to_string());
     warp::reply::html(render)
 }

--- a/examples/handlebars_template.rs
+++ b/examples/handlebars_template.rs
@@ -15,8 +15,10 @@ fn render<T>(template: WithTemplate<T>, hbs: Arc<Handlebars>) -> impl warp::Repl
 where
     T: Serialize,
 {
-    hbs.render(template.name, &template.value)
-        .unwrap_or_else(|err| err.to_string())
+    let render = hbs
+        .render(template.name, &template.value)
+        .unwrap_or_else(|err| err.to_string());
+    warp::reply::html(render)
 }
 
 #[tokio::main]

--- a/examples/routing.rs
+++ b/examples/routing.rs
@@ -25,7 +25,8 @@ async fn main() {
     // Any type that implements FromStr can be used, and in any order:
     //
     // GET /:u16/times/:u16
-    let times = warp::path!(u16 / "times" / u16).map(|a, b| format!("{} times {} = {}", a, b, a * b));
+    let times =
+        warp::path!(u16 / "times" / u16).map(|a, b| format!("{} times {} = {}", a, b, a * b));
 
     // Oh shoot, those math routes should be mounted at a different path,
     // is that possible? Yep.


### PR DESCRIPTION
Addresses issue #348 where handlebars_template example header is returning plain/text rather than text/html.   

The text now renders rather than displaying the html tagged content.

@jxs 
