### PR TITLE
Remove panic branch in `Message::as_bytes`.

### DIFF
--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -439,12 +439,14 @@ impl Message {
         }
     }
 
-    /// Return the bytes of this message.
-    pub fn as_bytes(&self) -> &[u8] {
+    /// Return the bytes of this message, if the message can contain data.
+    pub fn as_bytes(&self) -> Option<&[u8]> {
         match self.inner {
-            protocol::Message::Text(ref s) => s.as_bytes(),
-            protocol::Message::Binary(ref v) => v,
-            _ => unreachable!(),
+            protocol::Message::Text(ref s) => Some(s.as_bytes()),
+            protocol::Message::Binary(ref v) => Some(v),
+            protocol::Message::Ping(ref v) => Some(v),
+            protocol::Message::Pong(ref v) => Some(v),
+            protocol::Message::Close(_) => None,
         }
     }
 

--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -440,13 +440,13 @@ impl Message {
     }
 
     /// Return the bytes of this message, if the message can contain data.
-    pub fn as_bytes(&self) -> Option<&[u8]> {
+    pub fn as_bytes(&self) -> &[u8] {
         match self.inner {
-            protocol::Message::Text(ref s) => Some(s.as_bytes()),
-            protocol::Message::Binary(ref v) => Some(v),
-            protocol::Message::Ping(ref v) => Some(v),
-            protocol::Message::Pong(ref v) => Some(v),
-            protocol::Message::Close(_) => None,
+            protocol::Message::Text(ref s) => s.as_bytes(),
+            protocol::Message::Binary(ref v) => v,
+            protocol::Message::Ping(ref v) => v,
+            protocol::Message::Pong(ref v) => v,
+            protocol::Message::Close(_) => &[],
         }
     }
 

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -76,7 +76,7 @@ async fn binary() {
     client.send(warp::ws::Message::binary(&b"bonk"[..])).await;
     let msg = client.recv().await.expect("recv");
     assert!(msg.is_binary());
-    assert_eq!(msg.as_bytes(), b"bonk");
+    assert_eq!(msg.as_bytes(), Some(&b"bonk"[..]));
 }
 
 #[tokio::test]

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -76,7 +76,7 @@ async fn binary() {
     client.send(warp::ws::Message::binary(&b"bonk"[..])).await;
     let msg = client.recv().await.expect("recv");
     assert!(msg.is_binary());
-    assert_eq!(msg.as_bytes(), Some(&b"bonk"[..]));
+    assert_eq!(msg.as_bytes(), &b"bonk"[..]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Currently  using `as_bytes` panics in some cases. This patch handles all cases, by returning an option that is `Some` if the message contains a payload, and `None` if not.

Alternatively, this PR could be changed so that `Ping` and `Pong` messages also returned `None`, if preferred.

This requires changing the signature from `&[u8]` to `Option<&[u8]>`.