### PR TITLE
Add filters::ext::get_optional

### DIFF
--- a/src/filters/ext.rs
+++ b/src/filters/ext.rs
@@ -1,7 +1,7 @@
 //! Request Extensions
 
 use futures::future;
-use std::error::Error as StdError;
+use std::{convert::Infallible, error::Error as StdError};
 
 use crate::filter::{filter_fn_one, Filter};
 use crate::reject::{self, Rejection};
@@ -25,7 +25,7 @@ pub fn get<T: Clone + Send + Sync + 'static>(
 ///
 /// If the extension doesn't exist, it yields `None`.
 pub fn get_optional<T: Clone + Send + Sync + 'static>(
-) -> impl Filter<Extract = (Option<T>,), Error = Rejection> + Copy {
+) -> impl Filter<Extract = (Option<T>,), Error = Infallible> + Copy {
     filter_fn_one(|route| {
         let route = Ok(route.extensions().get::<T>().cloned());
         future::ready(route)

--- a/src/filters/ext.rs
+++ b/src/filters/ext.rs
@@ -21,6 +21,17 @@ pub fn get<T: Clone + Send + Sync + 'static>(
     })
 }
 
+/// Get a previously set extension of the current route.
+///
+/// If the extension doesn't exist, it yields `None`.
+pub fn get_optional<T: Clone + Send + Sync + 'static>(
+) -> impl Filter<Extract = (Option<T>,), Error = Rejection> + Copy {
+    filter_fn_one(|route| {
+        let route = Ok(route.extensions().get::<T>().cloned());
+        future::ready(route)
+    })
+}
+
 /// An error used to reject if `get` cannot find the extension.
 #[derive(Debug)]
 pub struct MissingExtension {


### PR DESCRIPTION
I love the warp and its concept. Thanks much for creating this framework!

This PR adds `filters::ext::get_optional` function. That is same as

```rust
filters::ext::get().map(|t| Some(t)).or_else(|_| None)
```

but more convenient and straightforward :)