### PR TITLE
impl Reject for T: Display + Debug

### DIFF
--- a/src/reject.rs
+++ b/src/reject.rs
@@ -145,6 +145,8 @@ fn __reject_custom_compilefail() {}
 // would be double-boxing it, and the downcasting wouldn't work as expected.
 pub trait Reject: fmt::Debug + Sized + Send + Sync + 'static {}
 
+impl<T: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static> Reject for T {}
+
 trait Cause: fmt::Debug + Send + Sync + 'static {
     fn as_any(&self) -> &dyn Any;
 }


### PR DESCRIPTION
- addresses #307 
- allows types which `impl std::error::Error` to not need `impl Reject for T {}` 
- allow one to just return:
```Rust
warp::reject::custom("quick rejection, TODO: improve into a type")
```
so that anyhow! dependency becomes unnecessary  