### PR TITLE
Allow or_else and recover to return infallible futures

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -239,7 +239,8 @@ pub trait Filter: FilterBase {
     where
         Self: Filter<Error = Rejection> + Sized,
         F: Func<Rejection>,
-        F::Output: Future<Output = Result<Self::Extract, Self::Error>> + Send,
+        F::Output: TryFuture<Ok = Self::Extract> + Send,
+        <F::Output as TryFuture>::Error: IsReject,
     {
         OrElse {
             filter: self,
@@ -251,14 +252,15 @@ pub trait Filter: FilterBase {
     /// returning a *new* type, instead of the *same* type.
     ///
     /// This is useful for "customizing" rejections into new response types.
-    /// See also the [errors example][ex].
+    /// See also the [rejections example][ex].
     ///
     /// [ex]: https://github.com/seanmonstar/warp/blob/master/examples/errors.rs
     fn recover<F>(self, fun: F) -> Recover<Self, F>
     where
         Self: Filter<Error = Rejection> + Sized,
         F: Func<Rejection>,
-        F::Output: TryFuture<Error = Self::Error> + Send,
+        F::Output: TryFuture + Send,
+        <F::Output as TryFuture>::Error: IsReject,
     {
         Recover {
             filter: self,

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -196,7 +196,7 @@ async fn or_else() {
     let foo = warp::path("foo");
     let bar = warp::path("bar");
 
-    let p = foo.and(bar.or_else(|_| future::ok(())));
+    let p = foo.and(bar.or_else(|_| future::ok::<_, std::convert::Infallible>(())));
 
     // /foo/bar
     let req = warp::test::request().path("/foo/nope");


### PR DESCRIPTION
I noticed that `or_else` and `recover` could conceivably be infallible (handle all error cases), but that couldn't be expressed in the type system, since they *required* the functions to return `Result<_, Rejection>`.

This allows `or_else` and `recover` combinators to be clearer about whether they too can reject, and also allows the compiler to better optimize if they handle all rejections.

This can disrupt type inference, so it's a breaking change, and needs to get in before the 0.2 release.