### PR TITLE
Add From<Reject> for Rejection.

### DIFF
--- a/src/reject.rs
+++ b/src/reject.rs
@@ -127,6 +127,8 @@ fn __reject_custom_compilefail() {}
 
 /// A marker trait to ensure proper types are used for custom rejections.
 ///
+/// Can be converted into Rejection.
+///
 /// # Example
 ///
 /// ```
@@ -312,6 +314,13 @@ impl Rejection {
         } else {
             false
         }
+    }
+}
+
+impl<T: Reject> From<T> for Rejection {
+    #[inline]
+    fn from(err: T) -> Rejection {
+        custom(err)
     }
 }
 


### PR DESCRIPTION
This allows the `?` operator to easily be used from within functions without `map_err`.