### PR TITLE
Body wrap filter

### DIFF
--- a/src/reject.rs
+++ b/src/reject.rs
@@ -553,6 +553,16 @@ mod sealed {
         fn into_response(&self) -> crate::reply::Response;
     }
 
+    impl IsReject for Box<dyn IsReject + 'static> {
+        fn status(&self) -> StatusCode {
+            self.as_ref().status()
+        }
+
+        fn into_response(&self) -> crate::reply::Response {
+            self.as_ref().into_response()
+        }
+    }
+
     fn _assert_object_safe() {
         fn _assert(_: &dyn IsReject) {}
     }

--- a/src/route.rs
+++ b/src/route.rs
@@ -139,4 +139,9 @@ impl Route {
             BodyState::Taken => None,
         }
     }
+
+    pub(crate) fn set_body(&mut self, body: Body) {
+        *self.req.body_mut() = body;
+        self.body = BodyState::Ready;
+    }
 }


### PR DESCRIPTION
I recognize that this code is probably not near polished enough to be included, but I wanted to submit an example of a solution to the issue I rose in #389 

The things I'm specifically worried about for this implementation are:
- using a `Pin<Box<async move {}>>` instead of finding a way to represent this as generics, or providing a type that directly implements `Future`
- Relying on errors being `Into<Rejection>`. This is fine if things can possibly reject, but for entirely infallible operations, this magically produces a `Rejection` error type.
- Silently ignoring possible rejections from the body future, specifically returning the `Option` rather than a `Result`
- Since the closure passed to `map_request_body` isn't really nameable, returning the result from a function becomes difficult

Despite these worries, I think this idea could be useful to future discussions