### PR TITLE
chore: remove cast from example

### DIFF
--- a/examples/dyn_reply.rs
+++ b/examples/dyn_reply.rs
@@ -3,10 +3,9 @@ use warp::{http::StatusCode, Filter};
 
 async fn dyn_reply(word: String) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
     if &word == "hello" {
-        // a cast is needed for now, see https://github.com/rust-lang/rust/issues/60424
-        Ok(Box::new("world") as Box<dyn warp::Reply>)
+        Ok(Box::new("world"))
     } else {
-        Ok(Box::new(StatusCode::BAD_REQUEST) as Box<dyn warp::Reply>)
+        Ok(Box::new(StatusCode::BAD_REQUEST))
     }
 }
 


### PR DESCRIPTION
The cast is not needed anymore as https://github.com/rust-lang/rust/issues/60424 has been fixed.