### PR TITLE
Add a tracing filter which enables contextual, structured logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,16 @@ rustls = { version = "0.16", optional = true }
 tungstenite = { default-features = false, version = "0.9", optional = true }
 urlencoding = "1.0.0"
 pin-project = "0.4.5"
+tracing = "0.1.12"
+tracing-futures = "0.2.1"
 
 [dev-dependencies]
 pretty_env_logger = "0.3"
 serde_derive = "1.0"
 handlebars = "1.0.0"
 tokio = { version = "0.2", features = ["macros"] }
+tracing-subscriber = "0.1.6"
+tracing-log = "0.1.1"
 
 [features]
 default = ["multipart", "websocket"]

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -19,6 +19,7 @@ pub mod path;
 pub mod query;
 pub mod reply;
 pub mod sse;
+pub mod tracing;
 #[cfg(feature = "websocket")]
 pub mod ws;
 

--- a/src/filters/tracing.rs
+++ b/src/filters/tracing.rs
@@ -1,0 +1,208 @@
+//! Tracing Filters
+
+use tracing::Span;
+
+use std::fmt;
+use std::net::SocketAddr;
+
+use http::{self, header};
+
+use crate::filter::{Filter, WrapSealed};
+use crate::reject::IsReject;
+use crate::reply::Reply;
+use crate::route::Route;
+
+use self::internal::WithTrace;
+
+/// Create a wrapping filter which adds a span with request info
+///
+/// # Example
+///
+/// ```
+/// use warp::Filter;
+///
+/// let route = warp::any()
+///     .map(warp::reply)
+///     .with(warp::tracing());
+/// ```
+pub fn tracing() -> Trace<impl Fn(Info) -> Span + Clone> {
+    let func = move |info: Info| {
+        tracing::info_span!(
+            "request",
+            remote_addr = %OptFmt(info.route.remote_addr()),
+            method = %info.method(),
+            path = %info.path(),
+            version = ?info.route.version(),
+            // status = %info.status().as_u16(),
+            referer = %OptFmt(info.referer()),
+            user_agent = %OptFmt(info.user_agent()),
+        )
+    };
+    Trace { func }
+}
+
+/// Create a wrapping filter which adds a custom span with request info
+///
+/// # Example
+///
+/// ```
+/// use warp::Filter;
+///
+/// let tracing = warp::tracing::custom(|info| {
+///     // Create a span using tracing macros
+///     tracing::info_span!(
+///         "request",
+///         method = %info.method(),
+///         path = %info.path(),
+///     );
+/// });
+/// let route = warp::any()
+///     .map(warp::reply)
+///     .with(tracing);
+/// ```
+pub fn custom<F>(func: F) -> Trace<F>
+where
+    F: Fn(Info) -> Span + Clone,
+{
+    Trace { func }
+}
+
+/// Decorates a [`Filter`](::Filter) to log requests and responses.
+#[derive(Clone, Copy, Debug)]
+pub struct Trace<F> {
+    func: F,
+}
+
+/// Information about the request/response that can be used to prepare log lines.
+#[allow(missing_debug_implementations)]
+pub struct Info<'a> {
+    route: &'a Route,
+}
+
+impl<FN, F> WrapSealed<F> for Trace<FN>
+where
+    FN: Fn(Info) -> Span + Clone + Send,
+    F: Filter + Clone + Send,
+    F::Extract: Reply,
+    F::Error: IsReject,
+{
+    type Wrapped = WithTrace<FN, F>;
+
+    fn wrap(&self, filter: F) -> Self::Wrapped {
+        WithTrace {
+            filter,
+            trace: self.clone(),
+        }
+    }
+}
+
+impl<'a> Info<'a> {
+    /// View the remote `SocketAddr` of the request.
+    pub fn remote_addr(&self) -> Option<SocketAddr> {
+        self.route.remote_addr()
+    }
+
+    /// View the `http::Method` of the request.
+    pub fn method(&self) -> &http::Method {
+        self.route.method()
+    }
+
+    /// View the URI path of the request.
+    pub fn path(&self) -> &str {
+        self.route.full_path()
+    }
+
+    /// View the `http::Version` of the request.
+    pub fn version(&self) -> http::Version {
+        self.route.version()
+    }
+
+    /// View the referer of the request.
+    pub fn referer(&self) -> Option<&str> {
+        self.route
+            .headers()
+            .get(header::REFERER)
+            .and_then(|v| v.to_str().ok())
+    }
+
+    /// View the user agent of the request.
+    pub fn user_agent(&self) -> Option<&str> {
+        self.route
+            .headers()
+            .get(header::USER_AGENT)
+            .and_then(|v| v.to_str().ok())
+    }
+
+    /// View the host of the request
+    pub fn host(&self) -> Option<&str> {
+        self.route
+            .headers()
+            .get(header::HOST)
+            .and_then(|v| v.to_str().ok())
+    }
+}
+
+struct OptFmt<T>(Option<T>);
+
+impl<T: fmt::Display> fmt::Display for OptFmt<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref t) = self.0 {
+            fmt::Display::fmt(t, f)
+        } else {
+            f.write_str("-")
+        }
+    }
+}
+
+mod internal {
+    use futures::{future::Inspect, FutureExt};
+
+    use std::future::Future;
+
+    use super::{Info, Trace};
+    use crate::filter::{Filter, FilterBase, Internal};
+    use crate::reject::IsReject;
+    use crate::reply::Reply;
+    use crate::route;
+
+    #[allow(missing_debug_implementations)]
+    #[derive(Clone, Copy)]
+    pub struct WithTrace<FN, F> {
+        pub(super) filter: F,
+        pub(super) trace: Trace<FN>,
+    }
+
+    use tracing::Span;
+    use tracing_futures::{Instrument, Instrumented};
+
+    impl<FN, F> FilterBase for WithTrace<FN, F>
+    where
+        FN: Fn(Info) -> Span + Clone + Send,
+        F: Filter + Clone + Send,
+        F::Extract: Reply,
+        F::Error: IsReject,
+    {
+        type Extract = F::Extract;
+        type Error = F::Error;
+        type Future = Inspect<Instrumented<F::Future>, fn(&<F::Future as Future>::Output)>;
+
+        fn filter(&self, _: Internal) -> Self::Future {
+            let span = route::with(|route| (self.trace.func)(Info { route }));
+            let _guard = span.enter();
+
+            fn finished_logger<R: Reply, E: IsReject>(reply: &Result<R, E>) {
+                if let Err(e) = reply {
+                    tracing::warn!(target: "warp::filters::tracing", msg = ?e, "error during processing");
+                } else {
+                    tracing::info!(target: "warp::filters::tracing", "successfully finished processing");
+                }
+            }
+
+            tracing::info!(target: "warp::filters::tracing", "processing request");
+            self.filter
+                .filter(Internal)
+                .in_current_span()
+                .inspect(finished_logger)
+        }
+    }
+}

--- a/src/filters/tracing.rs
+++ b/src/filters/tracing.rs
@@ -54,7 +54,7 @@ pub fn tracing() -> Trace<impl Fn(Info) -> Span + Clone> {
 ///         "request",
 ///         method = %info.method(),
 ///         path = %info.path(),
-///     );
+///     )
 /// });
 /// let route = warp::any()
 ///     .map(warp::reply)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,9 @@ pub use self::filters::{
     // query() function
     query::query,
     sse,
+    tracing,
+    // tracing() function
+    tracing::tracing,
 };
 // ws() function
 #[cfg(feature = "websocket")]

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -1,0 +1,44 @@
+use warp::Filter;
+
+#[tokio::test]
+async fn uses_tracing() {
+    // Setup a log subscriber (responsible to print to output)
+    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+        .with_env_filter("trace")
+        .without_time()
+        .finish();
+
+    // Set the previously created subscriber as the global subscriber
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+    // Redirect normal log messages to the tracing subscriber
+    tracing_log::LogTracer::init().unwrap();
+
+    // Start a span with some metadata (fields)
+    let span = tracing::debug_span!("app", domain = "www.example.org");
+    let _guard = span.enter();
+
+    log::error!("logged using log macro");
+
+    let ok = warp::any()
+        .map(|| {
+            tracing::error!("pre failure: this is printed");
+        })
+        .untuple_one()
+        .and(warp::path("aa"))
+        .map(|| {
+            tracing::error!("post failure: this is not printed");
+        })
+        .untuple_one()
+        .map(warp::reply)
+        // Here we add the tracing logger which will ensure that all requests has a span with
+        // useful information about the request (method, url, version, remote_addr, etc.)
+        .with(warp::tracing());
+
+    tracing::info!("logged using tracing macro");
+
+    // Send a request for /
+    let req = warp::test::request();
+    let resp = req.reply(&ok);
+
+    assert_eq!(resp.await.status(), 404);
+}


### PR DESCRIPTION
[Tracing](https://crates.io/crates/tracing) enables us to keep track of some contextual state throughout the lifetime of a request. This means that any logging done when processing a request will automatically also log the context. This is especially useful when processing requests in parallel because it means that one can separate intertwined logs.

The author of tracing made a good and informative [video](https://www.youtube.com/watch?v=JjItsfqFIdo) about the subject, and showing off some of the benefits.

This is based upon @emschwartz [issue](https://github.com/seanmonstar/warp/issues/288) and his previous work.

This is mainly a rough first implementation to see if you would like this feature. If you are interested in this feature I was planning to go through all uses of `log` in the crate to replace with appropriate `span`'s and `event`'s. What do you think @seanmonstar ?

Closes #288 