### PR TITLE
Adjust `warp::fs` rejections depending on File::open error kind

### DIFF
--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -244,13 +244,17 @@ fn file_reply(
                     log::debug!("file not found: {:?}", path.as_ref().display());
                     reject::not_found()
                 }
+                io::ErrorKind::PermissionDenied => {
+                    log::warn!("file permission denied: {:?}", path.as_ref().display());
+                    reject::known(FilePermissionError { _p: () })
+                }
                 _ => {
                     log::error!(
                         "file open error (path={:?}): {} ",
                         path.as_ref().display(),
                         err
                     );
-                    reject::not_found()
+                    reject::known(FileOpenError { _p: () })
                 }
             };
             Either::Right(future::err(rej))
@@ -448,6 +452,16 @@ fn get_block_size(metadata: &Metadata) -> usize {
 #[cfg(not(unix))]
 fn get_block_size(_metadata: &Metadata) -> usize {
     DEFAULT_READ_BUF_SIZE
+}
+
+// ===== Rejections =====
+
+unit_error! {
+    pub(crate) FileOpenError: "file open error"
+}
+
+unit_error! {
+    pub(crate) FilePermissionError: "file perimission error"
 }
 
 #[cfg(test)]

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -249,6 +249,8 @@ enum_known! {
     LengthRequired(LengthRequired),
     PayloadTooLarge(PayloadTooLarge),
     UnsupportedMediaType(UnsupportedMediaType),
+    FileOpenError(crate::fs::FileOpenError),
+    FilePermissionError(crate::fs::FilePermissionError),
     BodyReadError(crate::body::BodyReadError),
     BodyDeserializeError(crate::body::BodyDeserializeError),
     CorsForbidden(crate::cors::CorsForbidden),
@@ -394,10 +396,10 @@ impl Rejections {
                 Known::LengthRequired(_) => StatusCode::LENGTH_REQUIRED,
                 Known::PayloadTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
                 Known::UnsupportedMediaType(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                Known::CorsForbidden(_) => StatusCode::FORBIDDEN,
-                Known::MissingExtension(_) | Known::BodyConsumedMultipleTimes(_) => {
-                    StatusCode::INTERNAL_SERVER_ERROR
-                }
+                Known::FilePermissionError(_) | Known::CorsForbidden(_) => StatusCode::FORBIDDEN,
+                Known::FileOpenError(_)
+                | Known::MissingExtension(_)
+                | Known::BodyConsumedMultipleTimes(_) => StatusCode::INTERNAL_SERVER_ERROR,
             },
             Rejections::Custom(..) => StatusCode::INTERNAL_SERVER_ERROR,
             Rejections::Combined(ref a, ref b) => preferred(a, b).status(),


### PR DESCRIPTION
- Return 404 Not Found for NotFound
- Return 403 Forbidden for PermissionDenied
- Return 500 Internal Server Error for other errors