### PR TITLE
'Reply' example is testing the math() filter

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -64,7 +64,7 @@
 //! #[test]
 //! fn test_math() {
 //! #    let math = || warp::any().map(warp::reply);
-//!     let filter = sum();
+//!     let filter = math();
 //!
 //!     let res = warp::test::request()
 //!         .path("/1/2")


### PR DESCRIPTION
New to warp and reading the docs, the asserts here seem to apply to the math() filter.