### PR TITLE
feat: Add a or! macro to make or chaining more readable

### DIFF
--- a/src/filter/or.rs
+++ b/src/filter/or.rs
@@ -110,3 +110,28 @@ where
         }
     }
 }
+
+/// Convenient way to combine multiple filters with [`or`][Filter::or].
+/// `or!(a, b, c)` is equivalent to `a.or(b).or(c)`
+///
+/// ```
+/// use std::net::SocketAddr;
+/// use warp::or;
+///
+/// // Match either `/:u32` or `/:socketaddr`
+/// or!(
+///     warp::path::param::<u32>(),
+///     warp::path::param::<SocketAddr>(),
+///     warp::path::param::<String>(),
+/// );
+/// ```
+#[macro_export]
+macro_rules! or {
+    ($first: expr $(, $expr: expr)+ $(,)?) => { {
+        let filter = $first;
+        $(
+            let filter = $crate::Filter::or(filter, $expr);
+        )+
+        filter
+    } }
+}


### PR DESCRIPTION
There are some earlier discussions about more complicated macros (https://github.com/seanmonstar/warp/issues/26 and https://github.com/seanmonstar/warp/issues/395). But I believe a simple `or!` macro is quite useful on its own as it lets long `.or` chains be written without having the first filter being aligned differently or `.or` getting lost in the noise.

(Originally I called this `choice!` because of the equivalent macro I use in `combine` https://docs.rs/combine/4.0.1/combine/macro.choice.html but `or!` is probably more understandable. It could also be written as a function, using tuples to fake varargs https://docs.rs/combine/4.0.1/combine/fn.choice.html)