### PR TITLE
Websocket filter with tokio-tungstenite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ tokio = { version = "0.2", features = ["blocking", "fs", "stream", "sync", "time
 tower-service = "0.3"
 rustls = { version = "0.16", optional = true }
 # tls is enabled by default, we don't want that yet
-tungstenite = { default-features = false, version = "0.9", optional = true }
-tokio-tungstenite = { git = "https://github.com/snapview/tokio-tungstenite", branch = "master" }
+tokio-tungstenite = { version = "0.10", default-features = false, optional = true }
 urlencoding = "1.0.0"
 pin-project = "0.4.5"
 
@@ -47,7 +46,7 @@ tokio = { version = "0.2", features = ["macros"] }
 
 [features]
 default = ["multipart", "websocket"]
-websocket = ["tungstenite"]
+websocket = ["tokio-tungstenite"]
 tls = ["rustls"]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tower-service = "0.3"
 rustls = { version = "0.16", optional = true }
 # tls is enabled by default, we don't want that yet
 tungstenite = { default-features = false, version = "0.9", optional = true }
+tokio-tungstenite = { git = "https://github.com/snapview/tokio-tungstenite", branch = "master" }
 urlencoding = "1.0.0"
 pin-project = "0.4.5"
 

--- a/examples/rejections.rs
+++ b/examples/rejections.rs
@@ -27,13 +27,11 @@ async fn main() {
 
 /// Extract a denominator from a "div-by" header, or reject with DivideByZero.
 fn div_by() -> impl Filter<Extract = (NonZeroU16,), Error = Rejection> + Copy {
-    warp::header::<u16>("div-by").and_then(|n: u16| {
-        async move {
-            if let Some(denom) = NonZeroU16::new(n) {
-                Ok(denom)
-            } else {
-                Err(reject::custom(DivideByZero))
-            }
+    warp::header::<u16>("div-by").and_then(|n: u16| async move {
+        if let Some(denom) = NonZeroU16::new(n) {
+            Ok(denom)
+        } else {
+            Err(reject::custom(DivideByZero))
         }
     })
 }

--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -22,13 +22,13 @@ async fn main() {
         .and(warp::post())
         .and(warp::path::param::<usize>())
         .and(warp::body::content_length_limit(500))
-        .and(warp::body::bytes().and_then(|body: bytes::Bytes| {
-            async move {
+        .and(
+            warp::body::bytes().and_then(|body: bytes::Bytes| async move {
                 std::str::from_utf8(&body)
                     .map(String::from)
                     .map_err(|_e| warp::reject::custom(NotUtf8))
-            }
-        }))
+            }),
+        )
         .and(users.clone())
         .map(|my_id, msg, users| {
             user_message(my_id, msg, &users);

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -171,14 +171,14 @@ pub fn aggregate() -> impl Filter<Extract = (impl Buf,), Error = Rejection> + Co
 ///     });
 /// ```
 pub fn json<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
-    is_content_type::<Json>().and(aggregate()).and_then(|buf| {
-        async move {
+    is_content_type::<Json>()
+        .and(aggregate())
+        .and_then(|buf| async move {
             Json::decode(buf).map_err(|err| {
                 log::debug!("request json body error: {}", err);
                 reject::known(BodyDeserializeError { cause: err })
             })
-        }
-    })
+        })
 }
 
 /// Returns a `Filter` that matches any request and extracts a
@@ -206,14 +206,14 @@ pub fn json<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error =
 ///     });
 /// ```
 pub fn form<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
-    is_content_type::<Form>().and(aggregate()).and_then(|buf| {
-        async move {
+    is_content_type::<Form>()
+        .and(aggregate())
+        .and_then(|buf| async move {
             Form::decode(buf).map_err(|err| {
                 log::debug!("request form body error: {}", err);
                 reject::known(BodyDeserializeError { cause: err })
             })
-        }
-    })
+        })
 }
 
 // ===== Decoders =====

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -89,20 +89,18 @@ fn path_from_tail(
     base: Arc<PathBuf>,
 ) -> impl FilterClone<Extract = One<ArcPath>, Error = Rejection> {
     crate::path::tail().and_then(move |tail: crate::path::Tail| {
-        future::ready(sanitize_path(base.as_ref(), tail.as_str())).and_then(|mut buf| {
-            async {
-                let is_dir = tokio::fs::metadata(buf.clone())
-                    .await
-                    .map(|m| m.is_dir())
-                    .unwrap_or(false);
+        future::ready(sanitize_path(base.as_ref(), tail.as_str())).and_then(|mut buf| async {
+            let is_dir = tokio::fs::metadata(buf.clone())
+                .await
+                .map(|m| m.is_dir())
+                .unwrap_or(false);
 
-                if is_dir {
-                    log::debug!("dir: appending index.html to directory path");
-                    buf.push("index.html");
-                }
-                log::trace!("dir: {:?}", buf);
-                Ok(ArcPath(Arc::new(buf)))
+            if is_dir {
+                log::debug!("dir: appending index.html to directory path");
+                buf.push("index.html");
             }
+            log::trace!("dir: {:?}", buf);
+            Ok(ArcPath(Arc::new(buf)))
         })
     })
 }

--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -15,8 +15,11 @@ use futures::{future, FutureExt, Sink, Stream, TryFutureExt};
 use headers::{Connection, HeaderMapExt, SecWebsocketAccept, SecWebsocketKey, Upgrade};
 use http;
 use tokio_tungstenite::{
+    tungstenite::{
+        self,
+        protocol::{self, WebSocketConfig},
+    },
     WebSocketStream,
-    tungstenite::{self, protocol::{self, WebSocketConfig}}
 };
 
 /// Creates a Websocket Filter.

--- a/src/test.rs
+++ b/src/test.rs
@@ -509,7 +509,7 @@ impl WsBuilder {
                 upgraded,
                 protocol::Role::Client,
                 Default::default(),
-            );
+            ).await;
 
             let (tx, rx) = ws.split();
             let write = wr_rx.map(Ok).forward(tx).map(|_| ());

--- a/src/test.rs
+++ b/src/test.rs
@@ -509,7 +509,8 @@ impl WsBuilder {
                 upgraded,
                 protocol::Role::Client,
                 Default::default(),
-            ).await;
+            )
+            .await;
 
             let (tx, rx) = ws.split();
             let write = wr_rx.map(Ok).forward(tx).map(|_| ());

--- a/src/test.rs
+++ b/src/test.rs
@@ -469,7 +469,7 @@ impl WsBuilder {
         let (rd_tx, rd_rx) = mpsc::unbounded_channel();
 
         tokio::spawn(async move {
-            use tungstenite::protocol;
+            use tokio_tungstenite::tungstenite::protocol;
 
             let (addr, srv) = crate::serve(f).bind_ephemeral(([127, 0, 0, 1], 0));
 

--- a/tests/filter.rs
+++ b/tests/filter.rs
@@ -149,11 +149,9 @@ async fn unify() {
 #[should_panic]
 #[tokio::test]
 async fn nested() {
-    let f = warp::any().and_then(|| {
-        async {
-            let p = warp::path::param::<u32>();
-            warp::test::request().filter(&p).await
-        }
+    let f = warp::any().and_then(|| async {
+        let p = warp::path::param::<u32>();
+        warp::test::request().filter(&p).await
     });
 
     let _ = warp::test::request().filter(&f).await;


### PR DESCRIPTION
I tried to add support for `tokio-tungstenite` in the websocket filter. The only difference in the internal api is that `WebSocket::from_raw_websocket` now returns a Future.

The main problem right now is that the `tokio-tungstenite` dependency is from the github repository  because the version on crates.io uses futures v1.

Edit: Reference #366 