### PR TITLE
Upgrade automatically from http to https.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tokio-tungstenite = { version = "0.10", default-features = false, optional = tru
 urlencoding = "1.0.0"
 pin-project = "0.4.5"
 tokio-rustls = { version = "0.12.2", optional = true }
+tower-util = "0.3"
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -8,6 +8,10 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 pub trait Transport: AsyncRead + AsyncWrite {
     fn remote_addr(&self) -> Option<SocketAddr>;
+
+    fn upgrade_to_https(&self) -> bool {
+        false
+    }
 }
 
 impl Transport for AddrStream {


### PR DESCRIPTION
Fixes #417.

This gives the ability to handle upgrading HTTP to HTTPS on the same port.

-  by default disabled
-  on detecting a connection through HTTP, it will send a `301` status and a `Location: https://...` header
-  return `403` on failure to build `Location` header

This couldn't have been done without the help of @LucioFranco, @sfackler, @jxs, @davidbarsky, @darksonn (sorry for pulling you all in on this 😄) on discord, thanks everybody!

EDIT: relies on https://github.com/hyperium/hyper/pull/2127.