### PR TITLE
Add specialized Result type for warp errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,10 @@
 use std::convert::Infallible;
 use std::error::Error as StdError;
 use std::fmt;
+use std::result;
+
+/// A specialized `Result` type for warp errors.
+pub type Result<T> = result::Result<T, Error>;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,8 @@ pub use self::filter::Filter;
 // This otherwise shows a big dump of re-exports in the doc homepage,
 // with zero context, so just hide it from the docs. Doc examples
 // on each can show that a convenient import exists.
+#[doc(hidden)]
+pub use self::error::Result;
 #[cfg(feature = "multipart")]
 #[doc(hidden)]
 pub use self::filters::multipart;


### PR DESCRIPTION
This PR adds a specialized `Result` type alias, similar to the
`io::Result` alias seen in the stdlib.