### PR TITLE
Generalize Reply impl for Box<dyn Reply>

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -289,7 +289,7 @@ pub trait Reply: BoxedReply + Send {
     */
 }
 
-impl Reply for Box<dyn Reply> {
+impl<T: Reply + ?Sized> Reply for Box<T> {
     fn into_response(self) -> Response {
         self.boxed_into_response(Internal)
     }
@@ -541,7 +541,7 @@ mod sealed {
 
     impl<T: Reply> BoxedReply for T {
         fn boxed_into_response(self: Box<Self>, _: Internal) -> Response {
-            self.into_response()
+            (*self).into_response()
         }
     }
 }


### PR DESCRIPTION
We had a case where we were boxing up replies, and needed them to impl `Send + Sync` to use in other code. `Box<dyn Reply + Send + Sync>` unfortunately doesn't implement `Reply`, because the impl is too specific. This generalizes the impl of `Reply` to include any `Box<T>` where `T: Reply + ?Sized`.