### PR TITLE
Add Compression Filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        build: [stable, beta, nightly, tls, no-default-features]
+        build: [stable, beta, nightly, tls, no-default-features, compression]
 
         include:
           - build: beta
@@ -49,6 +49,8 @@ jobs:
             features: "--features tokio/uds"
           - build: no-default-features
             features: "--no-default-features"
+          - build: compression
+            features: "--features compression"
 
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 features = ["tls"]
 
 [dependencies]
-async-compression = { version = "0.3.1", features = ["brotli", "deflate", "gzip", "stream"] }
+async-compression = { version = "0.3.1", features = ["brotli", "deflate", "gzip", "stream"], optional = true }
 bytes = "0.5"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 headers = "0.3"
@@ -50,6 +50,7 @@ listenfd = "0.3"
 default = ["multipart", "websocket"]
 websocket = ["tokio-tungstenite"]
 tls = ["tokio-rustls"]
+compression = ["async-compression"]
 
 [profile.release]
 codegen-units = 1
@@ -66,6 +67,10 @@ required-features = ["multipart"]
 [[test]]
 name = "ws"
 required-features = ["websocket"]
+
+[[example]]
+name = "compression"
+required-features = ["compression"]
 
 [[example]]
 name = "unix_socket"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ edition = "2018"
 features = ["tls"]
 
 [dependencies]
+async-compression = { version = "0.3.1", features = ["gzip", "stream"] }
 bytes = "0.5"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 headers = "0.3"
 http = "0.2"
-hyper = "0.13"
+hyper = { version = "0.13", features = ["stream"] }
 log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 features = ["tls"]
 
 [dependencies]
-async-compression = { version = "0.3.1", features = ["gzip", "stream"] }
+async-compression = { version = "0.3.1", features = ["brotli", "deflate", "gzip", "stream"] }
 bytes = "0.5"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 headers = "0.3"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Thanks to its `Filter` system, warp provides these out of the box:
 * Static Files and Directories
 * Websockets
 * Access logging
+* Gzip, Deflate, and Brotli compression
 
 Since it builds on top of [hyper](https://hyper.rs), you automatically get:
 

--- a/examples/compression.rs
+++ b/examples/compression.rs
@@ -1,0 +1,34 @@
+#![deny(warnings)]
+
+use warp::Filter;
+
+#[tokio::main]
+async fn main() {
+    let file = warp::path("todos").and(warp::fs::file("./examples/todos.rs"));
+    // NOTE: You could double compress something by adding a compression
+    // filter here, a la
+    // ```
+    // let file = warp::path("todos")
+    //     .and(warp::fs::file("./examples/todos.rs"))
+    //     .with(warp::compression::brotli());
+    // ```
+    // This would result in a browser error, or downloading a file whose contents
+    // are compressed
+
+    let dir = warp::path("ws_chat").and(warp::fs::file("./examples/websockets_chat.rs"));
+
+    let file_and_dir = warp::get()
+        .and(file.or(dir))
+        .with(warp::compression::gzip());
+
+    let examples = warp::path("ex")
+        .and(warp::fs::dir("./examples/"))
+        .with(warp::compression::deflate());
+
+    // GET /todos => gzip -> toods.rs
+    // GET /ws_chat => gzip -> ws_chat.rs
+    // GET /ex/... => deflate -> ./examples/...
+    let routes = file_and_dir.or(examples);
+
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+}

--- a/examples/file.rs
+++ b/examples/file.rs
@@ -11,13 +11,11 @@ async fn main() {
         .and(warp::fs::file("./README.md"));
 
     // dir already requires GET...
-    let examples = warp::path("ex")
-        .and(warp::fs::dir("./examples/"))
-        .with(warp::compression::gzip());
+    let examples = warp::path("ex").and(warp::fs::dir("./examples/"));
 
     // GET / => README.md
     // GET /ex/... => ./examples/..
-    let routes = readme.or(examples).with(warp::log("info"));
+    let routes = readme.or(examples).with(warp::compression::brotli());
 
     warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
 }

--- a/examples/file.rs
+++ b/examples/file.rs
@@ -15,7 +15,7 @@ async fn main() {
 
     // GET / => README.md
     // GET /ex/... => ./examples/..
-    let routes = readme.or(examples).with(warp::compression::brotli());
+    let routes = readme.or(examples);
 
     warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
 }

--- a/examples/file.rs
+++ b/examples/file.rs
@@ -11,11 +11,13 @@ async fn main() {
         .and(warp::fs::file("./README.md"));
 
     // dir already requires GET...
-    let examples = warp::path("ex").and(warp::fs::dir("./examples/"));
+    let examples = warp::path("ex")
+        .and(warp::fs::dir("./examples/"))
+        .with(warp::compression::gzip());
 
     // GET / => README.md
     // GET /ex/... => ./examples/..
-    let routes = readme.or(examples);
+    let routes = readme.or(examples).with(warp::log("info"));
 
     warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
 }

--- a/src/filters/compression.rs
+++ b/src/filters/compression.rs
@@ -1,0 +1,182 @@
+//! Compression Filters
+
+use async_compression::stream::GzipEncoder;
+use bytes::Bytes;
+use futures::Stream;
+use http::header::{HeaderName, HeaderValue};
+use http::response::{Parts, Response as HttpResponse};
+use hyper::Body;
+use pin_project::pin_project;
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::filter::{Filter, WrapSealed};
+use crate::reject::IsReject;
+use crate::reply::{Reply, Response};
+
+use self::internal::WithCompression;
+
+/// Compression
+#[derive(Clone, Copy, Debug)]
+pub struct Compression<F> {
+    func: F,
+}
+
+/// blah blah blah
+pub fn gzip() -> Compression<impl Fn(CompressionProps) -> Response + Copy> {
+    let func = move |mut props: CompressionProps| {
+        let body = Body::wrap_stream(GzipEncoder::new(props.body));
+        props.head.headers.append(
+            HeaderName::from_static("content-encoding"),
+            HeaderValue::from_static("gzip"),
+        );
+        Response::from_parts(props.head, body)
+    };
+    Compression { func }
+}
+
+/// Compression Props
+#[derive(Debug)]
+pub struct CompressionProps {
+    body: CompressableBody,
+    head: Parts,
+}
+
+impl From<HttpResponse<Body>> for CompressionProps {
+    fn from(resp: HttpResponse<Body>) -> Self {
+        let (head, body) = resp.into_parts();
+        CompressionProps {
+            body: body.into(),
+            head,
+        }
+    }
+}
+
+/// A wrapper around [`Body`](hyper::Body) that implements [`Stream`](futures::Stream) to be
+/// compatible with async_compression's Stream based encoders
+#[pin_project]
+#[derive(Debug)]
+pub struct CompressableBody {
+    #[pin]
+    body: Body,
+}
+
+impl Stream for CompressableBody {
+    type Item = std::io::Result<Bytes>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        use std::io::{Error, ErrorKind};
+
+        let pin = self.project();
+        // TODO: Use `.map_err()` (https://github.com/rust-lang/rust/issues/63514) once it is stabilized
+        Body::poll_next(pin.body, cx)
+            .map(|e| e.map(|res| res.map_err(|_| Error::from(ErrorKind::InvalidData))))
+    }
+}
+
+impl From<Body> for CompressableBody {
+    fn from(body: Body) -> Self {
+        CompressableBody { body }
+    }
+}
+
+impl<FN, F> WrapSealed<F> for Compression<FN>
+where
+    FN: Fn(CompressionProps) -> Response + Clone + Send,
+    F: Filter + Clone + Send,
+    F::Extract: Reply,
+    F::Error: IsReject,
+{
+    type Wrapped = WithCompression<FN, F>;
+
+    fn wrap(&self, filter: F) -> Self::Wrapped {
+        WithCompression {
+            filter,
+            compress: self.clone(),
+        }
+    }
+}
+
+mod internal {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use futures::{ready, TryFuture};
+    use pin_project::pin_project;
+
+    // use bytes::Buf;
+    use crate::filter::{Filter, FilterBase, Internal};
+    use crate::reject::IsReject;
+    use crate::reply::{Reply, Response};
+    use crate::route;
+
+    use super::{Compression, CompressionProps};
+
+    #[allow(missing_debug_implementations)]
+    pub struct Compressed(pub(super) Response);
+
+    impl Reply for Compressed {
+        #[inline]
+        fn into_response(self) -> Response {
+            self.0
+        }
+    }
+
+    #[allow(missing_debug_implementations)]
+    #[derive(Clone, Copy)]
+    pub struct WithCompression<FN, F> {
+        pub(super) compress: Compression<FN>,
+        pub(super) filter: F,
+    }
+
+    impl<FN, F> FilterBase for WithCompression<FN, F>
+    where
+        FN: Fn(CompressionProps) -> Response + Clone + Send,
+        F: Filter + Clone + Send,
+        F::Extract: Reply,
+        F::Error: IsReject,
+    {
+        type Extract = (Compressed,);
+        type Error = F::Error;
+        type Future = WithCompressionFuture<FN, F::Future>;
+
+        fn filter(&self, _: Internal) -> Self::Future {
+            WithCompressionFuture {
+                compress: self.compress.clone(),
+                future: self.filter.filter(Internal),
+            }
+        }
+    }
+
+    #[allow(missing_debug_implementations)]
+    #[pin_project]
+    pub struct WithCompressionFuture<FN, F> {
+        compress: Compression<FN>,
+        #[pin]
+        future: F,
+    }
+
+    impl<FN, F> Future for WithCompressionFuture<FN, F>
+    where
+        FN: Fn(CompressionProps) -> Response,
+        F: TryFuture,
+        F::Ok: Reply,
+        F::Error: IsReject,
+    {
+        type Output = Result<(Compressed,), F::Error>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+            let pin = self.as_mut().project();
+            let result = ready!(pin.future.try_poll(cx));
+            match result {
+                Ok(reply) => {
+                    let resp = route::with(|_r| (self.compress.func)(reply.into_response().into()));
+                    Poll::Ready(Ok((Compressed(resp),)))
+                }
+                Err(reject) => Poll::Ready(Err(reject)),
+            }
+        }
+    }
+}

--- a/src/filters/compression.rs
+++ b/src/filters/compression.rs
@@ -1,4 +1,6 @@
 //! Compression Filters
+//!
+//! Filters that compress the body of a response.
 
 use async_compression::stream::{BrotliEncoder, DeflateEncoder, GzipEncoder};
 use http::header::HeaderValue;

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -6,6 +6,7 @@
 pub mod addr;
 pub mod any;
 pub mod body;
+#[cfg(feature = "compression")]
 pub mod compression;
 pub mod cookie;
 pub mod cors;

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -6,6 +6,7 @@
 pub mod addr;
 pub mod any;
 pub mod body;
+pub mod compression;
 pub mod cookie;
 pub mod cors;
 pub mod ext;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ pub use self::filters::{
     // any() function
     any::any,
     body,
+    compression,
     cookie,
     // cookie() function
     cookie::cookie,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,8 @@ mod transport;
 
 pub use self::error::Error;
 pub use self::filter::Filter;
+#[cfg(feature = "compression")]
+pub use self::filters::compression;
 // This otherwise shows a big dump of re-exports in the doc homepage,
 // with zero context, so just hide it from the docs. Doc examples
 // on each can show that a convenient import exists.
@@ -118,7 +120,6 @@ pub use self::filters::{
     // any() function
     any::any,
     body,
-    compression,
     cookie,
     // cookie() function
     cookie::cookie,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,11 +103,12 @@ mod transport;
 
 pub use self::error::Error;
 pub use self::filter::Filter;
-#[cfg(feature = "compression")]
-pub use self::filters::compression;
 // This otherwise shows a big dump of re-exports in the doc homepage,
 // with zero context, so just hide it from the docs. Doc examples
 // on each can show that a convenient import exists.
+#[cfg(feature = "compression")]
+#[doc(hidden)]
+pub use self::filters::compression;
 #[cfg(feature = "multipart")]
 #[doc(hidden)]
 pub use self::filters::multipart;


### PR DESCRIPTION
This PR adds compression filters to Warp, using the [`async-compression`](https://docs.rs/async-compression/0.3.1/async_compression/) crate. Compression is implemented by utilizing the fact that [`Body`](https://docs.rs/hyper/0.13.3/hyper/struct.Body.html) implements [`Stream`](https://docs.rs/futures/0.3.4/futures/stream/trait.Stream.html), and with a little bit of massaging we wrap the Response body in an encoder, and then create a new Body from that.

This implementation is definitely an MVP, there are two pitfalls a developer could fall into with this implementation
1. We don't check the `accept-encoding` header before compressing the Body, this could lead to some responses being invalid.
2. A user could theoretically double compress a response, leading to invalid responses.

From here there are a few more PRs that could be made
1. Add a `warp::compression::auto()` filter, that parses the `accept-encoding` header and selects a compression algo.
2. If `content-encoding` is already set, don't wrap the body in a another encoder, pass it through
3. For the `warp::compression::gzip(), etc.` filters, validate the `accept-encoding` header includes the proper value.
4. Add filters that allow you to set the quality of compression e.g. `warp::compression::gzip_with_quality(...)`

Because this is only an MVP, but also because this adds an additional dependency which is decently large, I put it behind a `"compression"` feature gate. When the feature is more flushed out we could remove the gate.


Resolves #46 