### PR TITLE
Add XML support for body & reply, as well as strict content-type checking options for easier filter composition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ scoped-tls = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.6"
-serde-xml-rs = { git = "https://github.com/RReverser/serde-xml-rs" }
+serde-xml-rs = "0.4.0"
 tokio = { version = "0.2", features = ["blocking", "fs", "stream", "sync", "time"] }
 tower-service = "0.3"
 # tls is enabled by default, we don't want that yet

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ scoped-tls = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.6"
+serde-xml-rs = { git = "https://github.com/RReverser/serde-xml-rs" }
 tokio = { version = "0.2", features = ["blocking", "fs", "stream", "sync", "time"] }
 tower-service = "0.3"
 # tls is enabled by default, we don't want that yet

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Thanks to its `Filter` system, warp provides these out of the box:
 * Path routing and parameter extraction
 * Header requirements and extraction
 * Query string deserialization
-* JSON and Form bodies
+* JSON, XML and Form bodies
 * Multipart form data
 * Static Files and Directories
 * Websockets

--- a/tests/body.rs
+++ b/tests/body.rs
@@ -255,7 +255,7 @@ async fn xml_rejects_bad_content_type() {
 async fn xml_invalid() {
     let _ = pretty_env_logger::try_init();
 
-    let xml = warp::body::xml::<Item>().map(|item| warp::reply::json(&item));
+    let xml = warp::body::xml::<Item>().map(|item| warp::reply::xml(&item));
 
     let res = warp::test::request().body("lol#wat").reply(&xml).await;
     assert_eq!(res.status(), 400);
@@ -267,7 +267,7 @@ async fn xml_invalid() {
 async fn xml_enforce_strict_content_type() {
     let _ = pretty_env_logger::try_init();
 
-    let xml = warp::body::xml_enforce_strict_content_type::<Item>().map(|_| warp::reply());
+    let xml = warp::body::xml_enforce_strict_content_type::<Item>().map(|_val| warp::reply());
 
     let req = warp::test::request().body("<item><name>Warp</name><source>GitHub</source></item>");
     let res = req.reply(&xml).await;
@@ -332,7 +332,7 @@ async fn xml_enforce_strict_content_type_invalid() {
     let _ = pretty_env_logger::try_init();
 
     let xml =
-        warp::body::xml_enforce_strict_content_type::<Item>().map(|item| warp::reply::json(&item));
+        warp::body::xml_enforce_strict_content_type::<Item>().map(|item| warp::reply::xml(&item));
 
     let res = warp::test::request()
         .body("lol#wat")


### PR DESCRIPTION
This pull request implements `warp::reply::xml()` and `warp::body::xml()` to match JSON functionality, as well as introducing strict type checking on content-type to allow for easier composition.

I've also added tests for XML & XML/JSON/Form with strict content types.

I would consider this a WIP because I couldn't find an example of how `warp::reply` is currently being tested, so I'd like to add tests for that as well.