### PR TITLE
Allow the max frame size to be set for a websocket

### DIFF
--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -172,6 +172,14 @@ impl Ws2 {
             .max_message_size = Some(max);
         self
     }
+
+    /// Set the maximum frame size (defaults to 16 megabytes)
+    pub fn max_frame_size(mut self, max: usize) -> Self {
+        self.config
+            .get_or_insert_with(|| WebSocketConfig::default())
+            .max_frame_size = Some(max);
+        self
+    }
 }
 
 impl fmt::Debug for Ws2 {


### PR DESCRIPTION
We had a problem in production with an overly large websocket message from chrome not being received in a warp based service. To solve this, we had to fork warp and allow the max_frame_size to be set.

We are using 0.1.x in this system, but if this is accepted we could also do an additional PR against master.