### PR TITLE
Implement host filter for parsing the host from the authority (http/2) or parsing the host header (http/1.x)

### DIFF
--- a/src/filters/host.rs
+++ b/src/filters/host.rs
@@ -1,0 +1,25 @@
+//! Host filter
+//!
+use futures::future;
+use crate::reject::{self, Rejection};
+use crate::filter::{Filter, filter_fn, one};
+
+/// Get the host of the route
+pub fn host() -> impl Filter<Extract = (Option<String>,), Error = Rejection> + Copy {
+    let name = "Host";
+
+    filter_fn(move |route| future::ok(one(
+        route.uri()
+            .authority()
+            .and_then(|authority| Some(authority.host()))
+            .and_then(|host| Some(host.to_string()))
+            .or_else(|| route.headers()
+                .get(name)
+                .ok_or_else(|| reject::missing_header(name))
+                .and_then(|value| value.to_str().map_err(|_| reject::invalid_header(name)))
+                .and_then(|s| Ok(String::from(s)))
+                .ok()
+            )
+        ))
+    )
+}

--- a/src/filters/host.rs
+++ b/src/filters/host.rs
@@ -1,28 +1,33 @@
 //! Host filter
 //!
-use crate::filter::{Filter, filter_fn, one};
+use std::str::FromStr;
+use crate::filter::{Filter, filter_fn_one, One};
 use crate::reject::{self, Rejection};
 use futures::future;
+use http::uri::Authority;
 
-/// Get the host of the route
-pub fn host() -> impl Filter<Extract = (Option<String>,), Error = Rejection> + Copy {
+/// Represents the hostname, returned by the `host()` filter.
+#[derive(Debug)]
+pub struct Host(Authority);
+
+/// Try to get the host of the route
+pub fn host() -> impl Filter<Extract = One<Option<Host>>, Error = Rejection> + Copy {
     let name = "Host";
 
-    filter_fn(move |route| {
-        future::ok(one(
+    filter_fn_one(move |route| {
+        future::ok(
             route.uri()
                 .authority()
-                .and_then(|authority| Some(authority.host()))
-                .and_then(|host| Some(host.to_string()))
-                .or_else(|| {
+                .and_then(|authority| Some(Host(authority.clone())))
+                .ok_or_else(|| {
                     route.headers()
                         .get(name)
                         .ok_or_else(|| reject::missing_header(name))
                         .and_then(|value| value.to_str().map_err(|_| reject::invalid_header(name)))
-                        .and_then(|s| Ok(String::from(s)))
-                        .ok()
+                        .and_then(|value| Authority::from_str(value).map_err(|_| reject::invalid_header(name)))
+                        .and_then(|authority| Ok(Host(authority)))
                 })
-            )
+                .ok()
         )
     })
 }

--- a/src/filters/host.rs
+++ b/src/filters/host.rs
@@ -1,25 +1,28 @@
 //! Host filter
 //!
-use futures::future;
-use crate::reject::{self, Rejection};
 use crate::filter::{Filter, filter_fn, one};
+use crate::reject::{self, Rejection};
+use futures::future;
 
 /// Get the host of the route
 pub fn host() -> impl Filter<Extract = (Option<String>,), Error = Rejection> + Copy {
     let name = "Host";
 
-    filter_fn(move |route| future::ok(one(
-        route.uri()
-            .authority()
-            .and_then(|authority| Some(authority.host()))
-            .and_then(|host| Some(host.to_string()))
-            .or_else(|| route.headers()
-                .get(name)
-                .ok_or_else(|| reject::missing_header(name))
-                .and_then(|value| value.to_str().map_err(|_| reject::invalid_header(name)))
-                .and_then(|s| Ok(String::from(s)))
-                .ok()
+    filter_fn(move |route| {
+        future::ok(one(
+            route.uri()
+                .authority()
+                .and_then(|authority| Some(authority.host()))
+                .and_then(|host| Some(host.to_string()))
+                .or_else(|| {
+                    route.headers()
+                        .get(name)
+                        .ok_or_else(|| reject::missing_header(name))
+                        .and_then(|value| value.to_str().map_err(|_| reject::invalid_header(name)))
+                        .and_then(|s| Ok(String::from(s)))
+                        .ok()
+                })
             )
-        ))
-    )
+        )
+    })
 }

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -23,5 +23,7 @@ pub mod reply;
 pub mod sse;
 #[cfg(feature = "websocket")]
 pub mod ws;
+mod host;
 
+pub use host::host;
 pub use crate::filter::BoxedFilter;


### PR DESCRIPTION
Related: https://github.com/seanmonstar/warp/issues/432

This is the initial version of parsing the host properly in Warp. First, it tries to parse the hostname based on the `:authority` pseudo-header. If that fails it tries to parse the `Host` header for http/1.1 and http/1.

I'm aware that this is probably not the final version as it's using a `Option<String>` where in the issue there was a mention about a `Host` type. Since I'm not an expert in Rust please advice what's missing or how it could be improved.

Thanks!