### PR TITLE
Set Remote Addr for Test Request Builder

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -227,6 +227,22 @@ impl RequestBuilder {
         self
     }
 
+    /// Set the remote address of this request
+    ///
+    /// Default is no remote address.
+    ///
+    /// # Example
+    /// ```
+    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    ///
+    /// let req = warp::test::request()
+    ///     .remote_addr(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080));
+    /// ```
+    pub fn remote_addr(mut self, addr: SocketAddr) -> Self {
+        self.remote_addr = Some(addr);
+        self
+    }
+
     /// Add a type to the request's `http::Extensions`.
     pub fn extension<T>(mut self, ext: T) -> Self
     where

--- a/tests/addr.rs
+++ b/tests/addr.rs
@@ -1,0 +1,24 @@
+#![deny(warnings)]
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+#[tokio::test]
+async fn remote_addr_missing() {
+    let extract_remote_addr = warp::addr::remote();
+
+    let req = warp::test::request();
+    let resp = req.filter(&extract_remote_addr).await.unwrap();
+    assert_eq!(resp, None)
+}
+
+#[tokio::test]
+async fn remote_addr_present() {
+    let extract_remote_addr = warp::addr::remote();
+
+    let req = warp::test::request().remote_addr("1.2.3.4:5678".parse().unwrap());
+    let resp = req.filter(&extract_remote_addr).await.unwrap();
+    assert_eq!(
+        resp,
+        Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 5678))
+    )
+}


### PR DESCRIPTION
Support setting the remote addr in the test request builder.

Leverage this functionality to validate the `warp::addr::remote` filter
works as intended.