### PR TITLE
add example showing how to serve a react-style SPA using warp

### DIFF
--- a/examples/html-with-js/main.rs
+++ b/examples/html-with-js/main.rs
@@ -1,0 +1,18 @@
+#![deny(warnings)]
+use warp::Filter;
+
+#[tokio::main]
+async fn main() {
+    // expose all of the files in public/
+    let public = warp::path!("examples" / "html-with-js" / "public")
+        .and(warp::fs::dir("examples/html-with-js/public"));
+
+    // GET / -> index html
+    let index = warp::get()
+        .and(warp::path::end())
+        .and(warp::fs::file("examples/html-with-js/public/index.html"));
+
+    let routes = index.or(public);
+
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+}

--- a/examples/html-with-js/public/index.html
+++ b/examples/html-with-js/public/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>html + javascript served at warp speeds</title>
+</head>
+
+<body>
+    <h1>warp</h1>
+    <!-- whichever path you put here must be exposed by the warp router.
+         In this case it's the `warp::path("examples/html-with-js/public").and(warp::fs::dir("examples/html-with-js/public"))`
+         which makes it so the browser can fetch the public/index.js file-->
+    <script src="examples/html-with-js/public/index.js"></script>
+
+</body>
+
+</html>

--- a/examples/html-with-js/public/index.js
+++ b/examples/html-with-js/public/index.js
@@ -1,0 +1,1 @@
+console.log("I'm being served at warp speed!");


### PR DESCRIPTION
I spent around a day trying to figure out how to serve a single page application via `warp` and once I figured it out I thought I'd add an example for it since i figured I'm not the only one looking to use warp for react-style apps.

This PR is not mergeable as is, because this example is still not loading the `index.js` javascript correct from the `index.html`. I need someone more familiar with `warp` to tell me what needs to change here before we can add this example.

Note: I was able to get this example to work by changing `main.js` so there is 1 route for the `index.html` and ` route for the `index.js`. However this is just a kludgy workaround because if I want to add another asset for the browser to fetch (e.g. `index.css`) then I have to go and add an additional route. I want to be able to just expose a single `public/` directory and then the browser can fetch any assets it contains.