### PR TITLE
Breaking Change: replace `Reject` trait with `Into<Rejection>`

### DIFF
--- a/examples/rejections.rs
+++ b/examples/rejections.rs
@@ -1,6 +1,7 @@
 #![deny(warnings)]
 
 use std::convert::Infallible;
+use std::fmt;
 use std::num::NonZeroU16;
 
 use serde_derive::Serialize;
@@ -38,8 +39,12 @@ fn div_by() -> impl Filter<Extract = (NonZeroU16,), Error = Rejection> + Copy {
 
 #[derive(Debug)]
 struct DivideByZero;
-
-impl reject::Reject for DivideByZero {}
+impl std::error::Error for DivideByZero {}
+impl fmt::Display for DivideByZero {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "cannot divide by zero")
+    }
+}
 
 // JSON replies
 

--- a/examples/rejections.rs
+++ b/examples/rejections.rs
@@ -1,12 +1,14 @@
 #![deny(warnings)]
 
 use std::convert::Infallible;
-use std::fmt;
 use std::num::NonZeroU16;
 
 use serde_derive::Serialize;
 use warp::http::StatusCode;
-use warp::{reject, Filter, Rejection, Reply};
+use warp::{
+    reject::{self, Debug},
+    Filter, Rejection, Reply,
+};
 
 /// Rejections represent cases where a filter should not continue processing
 /// the request, but a different filter *could* process it.
@@ -75,7 +77,7 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
         message = "METHOD_NOT_ALLOWED";
     } else {
         // We should have expected this... Just log and say its a 500
-        eprintln!("unhandled rejection: {:?}", err);
+        eprintln!("unhandled rejection: {:?}", err.debug());
         code = StatusCode::INTERNAL_SERVER_ERROR;
         message = "UNHANDLED_REJECTION";
     }

--- a/examples/rejections.rs
+++ b/examples/rejections.rs
@@ -39,12 +39,6 @@ fn div_by() -> impl Filter<Extract = (NonZeroU16,), Error = Rejection> + Copy {
 
 #[derive(Debug)]
 struct DivideByZero;
-impl std::error::Error for DivideByZero {}
-impl fmt::Display for DivideByZero {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "cannot divide by zero")
-    }
-}
 
 // JSON replies
 

--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -67,13 +67,6 @@ enum Message {
 
 #[derive(Debug)]
 struct NotUtf8;
-impl std::error::Error for NotUtf8 {}
-
-impl fmt::Display for NotUtf8 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "this is not utf8")
-    }
-}
 
 /// Our state of currently connected users.
 ///

--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -1,6 +1,5 @@
 use futures::{Stream, StreamExt};
 use std::collections::HashMap;
-use std::fmt;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Mutex,

--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -1,5 +1,6 @@
 use futures::{Stream, StreamExt};
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Mutex,
@@ -66,7 +67,13 @@ enum Message {
 
 #[derive(Debug)]
 struct NotUtf8;
-impl warp::reject::Reject for NotUtf8 {}
+impl std::error::Error for NotUtf8 {}
+
+impl fmt::Display for NotUtf8 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "this is not utf8")
+    }
+}
 
 /// Our state of currently connected users.
 ///

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -31,6 +31,7 @@ use self::recover::Recover;
 use self::unify::Unify;
 use self::untuple_one::UntupleOne;
 pub(crate) use self::wrap::{Wrap, WrapSealed};
+use crate::reject::RejectionDebug;
 
 // A crate-private base trait, allowing the actual `filter` method to change
 // signatures without it being a breaking change.
@@ -45,7 +46,7 @@ pub trait FilterBase {
     where
         Self: Sized,
         F: Fn(Self::Error) -> E + Clone,
-        E: ::std::fmt::Debug + Send,
+        E: RejectionDebug + Send,
     {
         MapErr {
             filter: self,

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -31,7 +31,7 @@ use self::recover::Recover;
 use self::unify::Unify;
 use self::untuple_one::UntupleOne;
 pub(crate) use self::wrap::{Wrap, WrapSealed};
-use crate::reject::RejectionDebug;
+use crate::reject::Debug;
 
 // A crate-private base trait, allowing the actual `filter` method to change
 // signatures without it being a breaking change.
@@ -46,7 +46,7 @@ pub trait FilterBase {
     where
         Self: Sized,
         F: Fn(Self::Error) -> E + Clone,
-        E: RejectionDebug + Send,
+        E: Debug + Send,
     {
         MapErr {
             filter: self,

--- a/src/filter/service.rs
+++ b/src/filter/service.rs
@@ -8,7 +8,7 @@ use futures::future::TryFuture;
 use hyper::service::Service;
 use pin_project::pin_project;
 
-use crate::reject::IsReject;
+use crate::reject::{IsReject, RejectionDebug};
 use crate::reply::{Reply, Response};
 use crate::route::{self, Route};
 use crate::{Filter, Request};
@@ -129,7 +129,7 @@ where
             Poll::Ready(Ok(ok)) => Poll::Ready(Ok(ok.into_response())),
             Poll::Pending => Poll::Pending,
             Poll::Ready(Err(err)) => {
-                log::debug!("rejected: {:?}", err);
+                log::debug!("rejected: {:?}", err.debug());
                 Poll::Ready(Ok(err.into_response()))
             }
         }

--- a/src/filter/service.rs
+++ b/src/filter/service.rs
@@ -8,7 +8,7 @@ use futures::future::TryFuture;
 use hyper::service::Service;
 use pin_project::pin_project;
 
-use crate::reject::{IsReject, RejectionDebug};
+use crate::reject::{Debug, IsReject};
 use crate::reply::{Reply, Response};
 use crate::route::{self, Route};
 use crate::{Filter, Request};

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -465,6 +465,7 @@ unit_error! {
 #[cfg(test)]
 mod tests {
     use super::sanitize_path;
+    use crate::reject::Debug;
     use bytes::BytesMut;
 
     #[test]
@@ -476,7 +477,9 @@ mod tests {
         }
 
         assert_eq!(
-            sanitize_path(base, "/foo.html").unwrap(),
+            sanitize_path(base, "/foo.html")
+                .map_err(|r| panic!("{:?}", r.debug()))
+                .unwrap(),
             p("/var/www/foo.html")
         );
 

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -267,6 +267,7 @@ tuple_fmt!((A, B, C, D, E, F, G, H) => (0, 1, 2, 3, 4, 5, 6, 7));
 /// Typically this identifier represented as number or string.
 ///
 /// ```
+/// use warp::reject::Debug;
 /// let app = warp::sse::last_event_id::<u32>();
 ///
 /// // The identifier is present
@@ -276,6 +277,7 @@ tuple_fmt!((A, B, C, D, E, F, G, H) => (0, 1, 2, 3, 4, 5, 6, 7));
 ///            .header("Last-Event-ID", "12")
 ///            .filter(&app)
 ///            .await
+///            .map_err(|r| panic!("{:?}", r.debug()))
 ///            .unwrap(),
 ///         Some(12)
 ///     );
@@ -285,6 +287,7 @@ tuple_fmt!((A, B, C, D, E, F, G, H) => (0, 1, 2, 3, 4, 5, 6, 7));
 ///        warp::test::request()
 ///            .filter(&app)
 ///            .await
+///            .map_err(|r| panic!("{:?}", r.debug()))
 ///            .unwrap(),
 ///         None
 ///     );

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -112,7 +112,7 @@ pub(crate) fn unsupported_media_type() -> Rejection {
 /// or else this will be returned as a `500 Internal Server Error`.
 ///
 /// [`recover`]: ../trait.Filter.html#method.recover
-pub fn custom<T: std::error::Error + Sized + Send + Sync + 'static>(err: T) -> Rejection {
+pub fn custom<T: Reject>(err: T) -> Rejection {
     Rejection::custom(Box::new(err))
 }
 
@@ -131,15 +131,16 @@ fn __reject_custom_compilefail() {}
 ///
 /// ```
 /// use warp::{Filter, reject::Reject};
+/// use std::fmt;
 ///
 /// #[derive(Debug)]
 /// struct RateLimited;
 ///
 /// impl std::error::Error for RateLimited {}
 ///
-/// impl fmt::Display for X {
+/// impl fmt::Display for RateLimited {
 ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(f, "X Error")
+///         write!(f, "RateLimited")
 ///     }
 /// }
 ///
@@ -289,10 +290,17 @@ impl Rejection {
     /// # Example
     ///
     /// ```
+    /// use std::fmt;
+    ///
     /// #[derive(Debug)]
     /// struct Nope;
+    /// impl std::error::Error for Nope {}
     ///
-    /// impl warp::reject::Reject for Nope {}
+    /// impl fmt::Display for Nope {
+    ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    ///         write!(f, "Nope")
+    ///     }
+    /// }
     ///
     /// let reject = warp::reject::custom(Nope);
     ///

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -324,7 +324,7 @@ where
     }
 }
 
-impl RejectionDebug for Infallible {
+impl Debug for Infallible {
     fn debug(&self) -> Box<dyn fmt::Debug> {
         match *self {}
     }
@@ -361,12 +361,12 @@ impl IsReject for Rejection {
 }
 
 ///
-pub trait RejectionDebug {
+pub trait Debug {
     ///
     fn debug(&self) -> Box<dyn std::fmt::Debug + '_>;
 }
 
-impl RejectionDebug for Rejection {
+impl Debug for Rejection {
     fn debug(&self) -> Box<dyn fmt::Debug + '_> {
         Box::new(RejectionDebugger(self))
     }
@@ -584,13 +584,13 @@ impl ::std::fmt::Display for MissingCookie {
 impl StdError for MissingCookie {}
 
 mod sealed {
-    use super::{Reason, Rejection, RejectionDebug, Rejections};
+    use super::{Debug, Reason, Rejection, Rejections};
     use http::StatusCode;
     use std::convert::Infallible;
 
     // This sealed trait exists to allow Filters to return either `Rejection`
     // or `!`. There are no other types that make sense, and so it is sealed.
-    pub trait IsReject: RejectionDebug + Send + Sync {
+    pub trait IsReject: Debug + Send + Sync {
         fn status(&self) -> StatusCode;
         fn into_response(&self) -> crate::reply::Response;
     }
@@ -819,7 +819,7 @@ mod tests {
     fn test_debug() {
         let rej = combine_n(3, X);
 
-        let s = format!("{:?}", rej);
+        let s = format!("{:?}", rej.debug());
         assert_eq!(s, "Rejection([X(0), X(1), X(2)])");
     }
 }

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use std::any::Any;
+use std::any::TypeId;
 use std::convert::Infallible;
 use std::error::Error as StdError;
 use std::fmt;
@@ -308,35 +309,6 @@ impl Rejection {
     }
 }
 
-///
-pub trait RejectionDebug {
-    ///
-    fn debug(&self) -> Box<dyn std::fmt::Debug + '_>;
-}
-
-impl RejectionDebug for Rejection {
-    fn debug(&self) -> Box<dyn fmt::Debug + '_> {
-        Box::new(RejectionDebugger(self))
-    }
-}
-
-struct RejectionDebugger<'a>(&'a Rejection);
-
-impl fmt::Debug for RejectionDebugger<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Rejection").field(&self.0.reason).finish()
-    }
-}
-
-// impl From<Infallible> for Rejection {
-//     #[inline]
-//     fn from(infallible: Infallible) -> Rejection {
-//         match infallible {}
-//     }
-// }
-
-use std::any::TypeId;
-
 impl<T> From<T> for Rejection
 where
     T: fmt::Debug + Sized + Send + Sync + 'static,
@@ -385,6 +357,26 @@ impl IsReject for Rejection {
             }
             Reason::Other(ref other) => other.into_response(),
         }
+    }
+}
+
+///
+pub trait RejectionDebug {
+    ///
+    fn debug(&self) -> Box<dyn std::fmt::Debug + '_>;
+}
+
+impl RejectionDebug for Rejection {
+    fn debug(&self) -> Box<dyn fmt::Debug + '_> {
+        Box::new(RejectionDebugger(self))
+    }
+}
+
+struct RejectionDebugger<'a>(&'a Rejection);
+
+impl fmt::Debug for RejectionDebugger<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Rejection").field(&self.0.reason).finish()
     }
 }
 

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -136,14 +136,6 @@ fn __reject_custom_compilefail() {}
 /// #[derive(Debug)]
 /// struct RateLimited;
 ///
-/// impl std::error::Error for RateLimited {}
-///
-/// impl fmt::Display for RateLimited {
-///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(f, "RateLimited")
-///     }
-/// }
-///
 /// let route = warp::any().and_then(|| async {
 ///     Err::<(), _>(warp::reject::custom(RateLimited))
 /// });
@@ -284,13 +276,6 @@ impl Rejection {
     ///
     /// #[derive(Debug)]
     /// struct Nope;
-    /// impl std::error::Error for Nope {}
-    ///
-    /// impl fmt::Display for Nope {
-    ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    ///         write!(f, "Nope")
-    ///     }
-    /// }
     ///
     /// let reject = warp::reject::custom(Nope);
     ///
@@ -714,21 +699,6 @@ mod tests {
     #[derive(Debug, PartialEq)]
     struct Right;
 
-    impl std::error::Error for Left {}
-    impl std::error::Error for Right {}
-
-    impl fmt::Display for Left {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "Left Error")
-        }
-    }
-
-    impl fmt::Display for Right {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "Right Error")
-        }
-    }
-
     #[test]
     fn rejection_status() {
         assert_eq!(not_found().status(), StatusCode::NOT_FOUND);
@@ -838,12 +808,6 @@ mod tests {
 
     #[derive(Debug)]
     struct X(u32);
-    impl std::error::Error for X {}
-    impl fmt::Display for X {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "X Error")
-        }
-    }
 
     fn combine_n<F, R>(n: u32, new_reject: F) -> Rejection
     where

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -117,21 +117,12 @@ pub fn custom(err: impl Into<Rejection>) -> Rejection {
     err.into()
 }
 
-/// Protect against re-rejecting a rejection.
-///
-/// ```compile_fail
-/// fn with(r: warp::Rejection) {
-///     let _wat = warp::reject::custom(r);
-/// }
-/// ```
-fn __reject_custom_compilefail() {}
-
 /// A marker trait to ensure proper types are used for custom rejections.
 ///
 /// # Example
 ///
 /// ```
-/// use warp::{Filter, reject::Reject};
+/// use warp::Filter;
 /// use std::fmt;
 ///
 /// #[derive(Debug)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -103,8 +103,8 @@ use serde_json;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::filter::Filter;
+use crate::reject::Debug;
 use crate::reject::IsReject;
-use crate::reject::RejectionDebug;
 use crate::reply::Reply;
 use crate::route::{self, Route};
 use crate::Request;

--- a/src/test.rs
+++ b/src/test.rs
@@ -104,6 +104,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::filter::Filter;
 use crate::reject::IsReject;
+use crate::reject::RejectionDebug;
 use crate::reply::Reply;
 use crate::route::{self, Route};
 use crate::Request;
@@ -372,7 +373,7 @@ impl RequestBuilder {
                 let res = match result {
                     Ok(rep) => rep.into_response(),
                     Err(rej) => {
-                        log::debug!("rejected: {:?}", rej);
+                        log::debug!("rejected: {:?}", rej.debug());
                         rej.into_response()
                     }
                 };

--- a/src/test.rs
+++ b/src/test.rs
@@ -291,6 +291,7 @@ impl RequestBuilder {
     /// # Example
     ///
     /// ```no_run
+    /// use warp::reject::Debug;
     /// async {
     ///     let param = warp::path::param::<u32>();
     ///
@@ -298,6 +299,7 @@ impl RequestBuilder {
     ///         .path("/41")
     ///         .filter(&param)
     ///         .await
+    ///         .map_err(|r| panic!("{:?}", r.debug()))
     ///         .unwrap();
     ///
     ///     assert_eq!(ex, 41);

--- a/tests/cookie.rs
+++ b/tests/cookie.rs
@@ -1,14 +1,27 @@
 #![deny(warnings)]
+use warp::reject::Debug;
 
 #[tokio::test]
 async fn cookie() {
     let foo = warp::cookie("foo");
 
     let req = warp::test::request().header("cookie", "foo=bar");
-    assert_eq!(req.filter(&foo).await.unwrap(), "bar");
+    assert_eq!(
+        req.filter(&foo)
+            .await
+            .map_err(|r| panic!("{:?}", r.debug()))
+            .unwrap(),
+        "bar"
+    );
 
     let req = warp::test::request().header("cookie", "abc=def; foo=baz");
-    assert_eq!(req.filter(&foo).await.unwrap(), "baz");
+    assert_eq!(
+        req.filter(&foo)
+            .await
+            .map_err(|r| panic!("{:?}", r.debug()))
+            .unwrap(),
+        "baz"
+    );
 
     let req = warp::test::request().header("cookie", "abc=def");
     assert!(!req.matches(&foo).await);

--- a/tests/ext.rs
+++ b/tests/ext.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+use warp::reject::Debug;
 use warp::Filter;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -12,6 +13,7 @@ async fn set_and_get() {
         .extension(Ext1(55))
         .filter(&ext)
         .await
+        .map_err(|r| panic!("{:?}", r.debug()))
         .unwrap();
 
     assert_eq!(extracted, Ext1(55));

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-use warp::Filter;
+use warp::{reject::Debug, Filter};
 
 #[tokio::test]
 async fn exact() {
@@ -50,6 +50,7 @@ async fn optional() {
     let val = warp::test::request()
         .filter(&con_len)
         .await
+        .map_err(|r| panic!("{:?}", r.debug()))
         .expect("missing header matches");
     assert_eq!(val, None);
 
@@ -57,6 +58,7 @@ async fn optional() {
         .header("content-length", "5")
         .filter(&con_len)
         .await
+        .map_err(|r| panic!("{:?}", r.debug()))
         .expect("existing header matches");
 
     assert_eq!(val, Some(5));

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 use bytes::BufMut;
 use futures::{TryFutureExt, TryStreamExt};
-use warp::{multipart, Filter};
+use warp::{multipart, reject::Debug, Filter};
 
 #[tokio::test]
 async fn form_fields() {
@@ -48,7 +48,11 @@ async fn form_fields() {
         )
         .body(body);
 
-    let vec = req.filter(&route).await.unwrap();
+    let vec = req
+        .filter(&route)
+        .await
+        .map_err(|r| panic!("{:?}", r.debug()))
+        .unwrap();
     assert_eq!(&vec[0].0, "foo");
     assert_eq!(&vec[0].1, b"bar");
 }

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -3,7 +3,7 @@
 extern crate warp;
 
 use futures::future;
-use warp::Filter;
+use warp::{reject::Debug, Filter};
 
 #[tokio::test]
 async fn path() {
@@ -35,12 +35,24 @@ async fn param() {
     let num = warp::path::param::<u32>();
 
     let req = warp::test::request().path("/321");
-    assert_eq!(req.filter(&num).await.unwrap(), 321);
+    assert_eq!(
+        req.filter(&num)
+            .await
+            .map_err(|r| panic!("{:?}", r.debug()))
+            .unwrap(),
+        321
+    );
 
     let s = warp::path::param::<String>();
 
     let req = warp::test::request().path("/warp");
-    assert_eq!(req.filter(&s).await.unwrap(), "warp");
+    assert_eq!(
+        req.filter(&s)
+            .await
+            .map_err(|r| panic!("{:?}", r.debug()))
+            .unwrap(),
+        "warp"
+    );
 
     // u32 doesn't extract a non-int
     let req = warp::test::request().path("/warp");
@@ -49,7 +61,13 @@ async fn param() {
     let combo = num.map(|n| n + 5).and(s);
 
     let req = warp::test::request().path("/42/vroom");
-    assert_eq!(req.filter(&combo).await.unwrap(), (47, "vroom".to_string()));
+    assert_eq!(
+        req.filter(&combo)
+            .await
+            .map_err(|r| panic!("{:?}", r.debug()))
+            .unwrap(),
+        (47, "vroom".to_string())
+    );
 
     // empty segments never match
     let req = warp::test::request();
@@ -142,6 +160,7 @@ async fn tail() {
         .path("/foo/bar")
         .filter(&and)
         .await
+        .map_err(|r| panic!("{:?}", r.debug()))
         .unwrap();
     assert_eq!(ex.as_str(), "bar");
 
@@ -214,11 +233,23 @@ async fn path_macro() {
 
     let req = warp::test::request().path("/foo/bar");
     let p = path!(String / "bar");
-    assert_eq!(req.filter(&p).await.unwrap(), "foo");
+    assert_eq!(
+        req.filter(&p)
+            .await
+            .map_err(|r| panic!("{:?}", r.debug()))
+            .unwrap(),
+        "foo"
+    );
 
     let req = warp::test::request().path("/foo/bar");
     let p = path!("foo" / String);
-    assert_eq!(req.filter(&p).await.unwrap(), "bar");
+    assert_eq!(
+        req.filter(&p)
+            .await
+            .map_err(|r| panic!("{:?}", r.debug()))
+            .unwrap(),
+        "bar"
+    );
 
     // Requires path end
 
@@ -279,6 +310,7 @@ async fn full_path() {
         .path("/foo/bar")
         .filter(&and)
         .await
+        .map_err(|r| panic!("{:?}", r.debug()))
         .unwrap();
     assert_eq!(ex.as_str(), "/foo/bar");
 
@@ -288,6 +320,7 @@ async fn full_path() {
         .path("/foo/bar")
         .filter(&and)
         .await
+        .map_err(|r| panic!("{:?}", r.debug()))
         .unwrap();
     assert_eq!(ex.as_str(), "/foo/bar");
 
@@ -297,6 +330,7 @@ async fn full_path() {
         .path("/foo/123")
         .filter(&and)
         .await
+        .map_err(|r| panic!("{:?}", r.debug()))
         .unwrap();
     assert_eq!(ex.as_str(), "/foo/123");
 
@@ -339,6 +373,7 @@ async fn peek() {
         .path("/foo/bar")
         .filter(&and)
         .await
+        .map_err(|r| panic!("{:?}", r.debug()))
         .unwrap();
     assert_eq!(ex.as_str(), "bar");
 
@@ -348,6 +383,7 @@ async fn peek() {
         .path("/foo/bar")
         .filter(&and)
         .await
+        .map_err(|r| panic!("{:?}", r.debug()))
         .unwrap();
     assert_eq!(ex.as_str(), "foo/bar");
 
@@ -357,6 +393,7 @@ async fn peek() {
         .path("/foo/123")
         .filter(&and)
         .await
+        .map_err(|r| panic!("{:?}", r.debug()))
         .unwrap();
     assert_eq!(ex.as_str(), "");
 

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -2,6 +2,7 @@
 
 use serde_derive::Deserialize;
 use std::collections::HashMap;
+use warp::reject::Debug;
 use warp::Filter;
 
 #[tokio::test]
@@ -10,7 +11,11 @@ async fn query() {
 
     let req = warp::test::request().path("/?foo=bar&baz=quux");
 
-    let extracted = req.filter(&as_map).await.unwrap();
+    let extracted = req
+        .filter(&as_map)
+        .await
+        .map_err(|r| panic!("{:?}", r.debug()))
+        .unwrap();
     assert_eq!(extracted["foo"], "bar");
     assert_eq!(extracted["baz"], "quux");
 }
@@ -21,7 +26,11 @@ async fn query_struct() {
 
     let req = warp::test::request().path("/?foo=bar&baz=quux");
 
-    let extracted = req.filter(&as_struct).await.unwrap();
+    let extracted = req
+        .filter(&as_struct)
+        .await
+        .map_err(|r| panic!("{:?}", r.debug()))
+        .unwrap();
     assert_eq!(
         extracted,
         MyArgs {
@@ -37,7 +46,11 @@ async fn empty_query_struct() {
 
     let req = warp::test::request().path("/?");
 
-    let extracted = req.filter(&as_struct).await.unwrap();
+    let extracted = req
+        .filter(&as_struct)
+        .await
+        .map_err(|r| panic!("{:?}", r.debug()))
+        .unwrap();
     assert_eq!(
         extracted,
         MyArgs {
@@ -53,7 +66,11 @@ async fn missing_query_struct() {
 
     let req = warp::test::request().path("/");
 
-    let extracted = req.filter(&as_struct).await.unwrap();
+    let extracted = req
+        .filter(&as_struct)
+        .await
+        .map_err(|r| panic!("{:?}", r.debug()))
+        .unwrap();
     assert_eq!(
         extracted,
         MyArgs {
@@ -75,7 +92,11 @@ async fn required_query_struct() {
 
     let req = warp::test::request().path("/?foo=bar&baz=quux");
 
-    let extracted = req.filter(&as_struct).await.unwrap();
+    let extracted = req
+        .filter(&as_struct)
+        .await
+        .map_err(|r| panic!("{:?}", r.debug()))
+        .unwrap();
     assert_eq!(
         extracted,
         MyRequiredArgs {
@@ -118,6 +139,10 @@ async fn raw_query() {
 
     let req = warp::test::request().path("/?foo=bar&baz=quux");
 
-    let extracted = req.filter(&as_raw).await.unwrap();
+    let extracted = req
+        .filter(&as_raw)
+        .await
+        .map_err(|r| panic!("{:?}", r.debug()))
+        .unwrap();
     assert_eq!(extracted, "foo=bar&baz=quux".to_owned());
 }


### PR DESCRIPTION
I'm not sure this is the best approach yet but the goal rn it to make it so warp can support 3rd party error types like `anyhow` and `eyre` without those types having to have a conditional dependency on warp just to impl the Reject trait.