### PR TITLE
Add explicit error to WebSocket Message `to_str` method

### DIFF
--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::fmt;
 use std::future::Future;
+use std::io::{self};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -323,10 +324,13 @@ impl Message {
     }
 
     /// Try to get a reference to the string text, if this is a Text message.
-    pub fn to_str(&self) -> Result<&str, ()> {
+    pub fn to_str(&self) -> Result<&str, crate::Error> {
         match self.inner {
             protocol::Message::Text(ref s) => Ok(s),
-            _ => Err(()),
+            _ => Err(crate::Error::new(io::Error::new(
+                io::ErrorKind::Other,
+                "function protocol::Message::Text variant assumption not satisfied",
+            ))),
         }
     }
 


### PR DESCRIPTION
I used guidance from https://github.com/seanmonstar/warp/blob/497505a50508ec15dbfdc984c24026f957f28738/src/tls.rs#L165 and https://github.com/seanmonstar/warp/blob/fbbbc5b8377914463e4411ef6fc48bfd97d15a6d/src/filters/ws.rs#L196.  Please inform me if it can be improved.