### PR TITLE
Add Log constructor

### DIFF
--- a/src/filters/log.rs
+++ b/src/filters/log.rs
@@ -83,6 +83,13 @@ pub struct Log<F> {
     func: F,
 }
 
+impl<F> Log<F> {
+    /// Create a new logger.
+    pub fn new(func: F) -> Log<F> {
+        Log { func }
+    }
+}
+
 /// Information about the request/response that can be used to prepare log lines.
 #[allow(missing_debug_implementations)]
 pub struct Info<'a> {


### PR DESCRIPTION
**Motivation**
Without a constructor and with the `func` field private, it is impossible to use the `Log` struct in order to implement new logging schemes or diagnostics.

There is a large amount of useful implementation surrounding `Log` which users could harness. Both `Log` and `Info` are public structs.