### PR TITLE
update example with more complex routes

### DIFF
--- a/examples/autoreload.rs
+++ b/examples/autoreload.rs
@@ -15,14 +15,25 @@ extern crate listenfd;
 /// ```
 #[tokio::main]
 async fn main() {
-    // Match any request and return hello world!
-    let routes = warp::any().map(|| "Hello, World!");
+    // Get README.md file for every first level path
+    let readme = warp::get()
+        .and(warp::path::end())
+        .and(warp::fs::file("./README.md"));
+
+    // Get examples directory if the path match with ex
+    let examples = warp::path("ex").and(warp::fs::dir("./examples/"));
+
+    let routes = readme.or(examples);
 
     // hyper let's us build a server from a TcpListener (which will be
     // useful shortly). Thus, we'll need to convert our `warp::Filter` into
     // a `hyper::service::MakeService` for use with a `hyper::server::Server`.
     let svc = warp::service(routes);
-    let make_svc = hyper::service::make_service_fn(|_: _| async move { Ok::<_, Infallible>(svc) });
+    let make_svc = hyper::service::make_service_fn(|_: _| {
+        // clone svc is needed to avoid the error move out of svc
+        let svc = svc.clone();
+        async move { Ok::<_, Infallible>(svc) }
+    });
 
     let mut listenfd = ListenFd::from_env();
     // if listenfd doesn't take a TcpListener (i.e. we're not running via

--- a/examples/autoreload.rs
+++ b/examples/autoreload.rs
@@ -22,13 +22,12 @@ async fn main() {
     // useful shortly). Thus, we'll need to convert our `warp::Filter` into
     // a `hyper::service::MakeService` for use with a `hyper::server::Server`.
     let svc = warp::service(routes);
-    // clone svc is needed to avoid the error move out of svc. It happens when there is
-    // closure inside of the filter
-    // let make_svc = hyper::service::make_service_fn(|_: _| {
-    //   let svc = svc.clone();
-    //   async move { Ok::<_, Infallible>(svc) }
-    // });
-    let make_svc = hyper::service::make_service_fn(|_: _| async move { Ok::<_, Infallible>(svc) });
+
+    let make_svc = hyper::service::make_service_fn(|_: _| {
+        // the clone is there because not all warp filters impl Copy
+        let svc = svc.clone();
+        async move { Ok::<_, Infallible>(svc) }
+    });
 
     let mut listenfd = ListenFd::from_env();
     // if listenfd doesn't take a TcpListener (i.e. we're not running via


### PR DESCRIPTION
This example show how to use systemfd in a routes with closure and avoid the error

```rust
  --> src/main.rs:10:1
   |
10 | #[tokio::main]
   | ^^^^^^^^^^^^^^
   | |
   | captured outer variable
   | move occurs because `svc` has type `warp::filter::service::FilteredService<warp::filter::or::Or<warp::filter::and::And<impl warp::Filter+std::marker::Copy, impl warp::filter::FilterClone>, warp::filter::and::And<impl warp::Filter+std::marker::Copy, impl warp::filter::FilterClone>>>`, which does not implement the `Copy` trait
   | move out of `svc` occurs here
   | move occurs due to use in generator
```