### PR TITLE
Add filter method flatten()

### DIFF
--- a/src/filter/flatten.rs
+++ b/src/filter/flatten.rs
@@ -1,0 +1,100 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::{ready, TryFuture};
+use pin_project::{pin_project, project};
+
+use super::{Filter, FilterBase, Func, Internal};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Flatten<T, F> {
+    pub(super) filter: T,
+    pub(super) callback: F,
+}
+
+impl<T, F> FilterBase for Flatten<T, F>
+where
+    T: Filter,
+    F: Func<T::Extract> + Clone + Send,
+    F::Output: Future + Send,
+    <F::Output as Future>::Output: Filter<Error = T::Error>,
+{
+    type Extract = <<F::Output as Future>::Output as FilterBase>::Extract;
+    type Error = T::Error;
+    type Future = FlattenFuture<T, F>;
+    #[inline]
+    fn filter(&self, _: Internal) -> Self::Future {
+        FlattenFuture::EvalFirst {
+            first_future: self.filter.filter(Internal),
+            callback: self.callback.clone(),
+        }
+    }
+}
+
+#[allow(missing_debug_implementations)]
+#[pin_project]
+pub enum FlattenFuture<T: Filter, F>
+    where 
+        T: Filter,
+        F: Func<T::Extract>,
+        F::Output: Future,
+        <F::Output as Future>::Output: Filter<Error = T::Error>,
+{
+    EvalFirst {
+        #[pin]
+        first_future: T::Future,
+        callback: F,
+    },
+    EvalCallback {
+        #[pin]
+        callback_future: F::Output,
+    },
+    EvalSecond {
+        #[pin]
+        second_future: <<F::Output as Future>::Output as FilterBase>::Future,
+    }
+}
+
+impl<T, F> Future for FlattenFuture<T, F>
+where
+    T: Filter,
+    F: Func<T::Extract> + Clone,
+    F::Output: Future,
+    <F::Output as Future>::Output: Filter<Error = T::Error>,
+{
+    type Output = Result<<<F::Output as Future>::Output as FilterBase>::Extract, <<F::Output as Future>::Output as FilterBase>::Error>;
+
+    #[inline]
+    #[project]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        loop {
+            let pin = self.as_mut().project(); 
+            #[project]
+            match pin {
+                FlattenFuture::EvalFirst{first_future, callback} => {
+                    match ready!(first_future.poll(cx)) {
+                        Ok(ex) => {
+                            let callback_future = callback.call(ex);
+                            self.set(FlattenFuture::EvalCallback{callback_future});
+                        }
+                        Err(e) => {
+                            return Poll::Ready(Err(e));
+                        }
+                    }
+                }
+                FlattenFuture::EvalCallback{callback_future} => {
+                    let filter = ready!(callback_future.poll(cx));
+                    let second_future = filter.filter(Internal);
+                    self.set(FlattenFuture::EvalSecond{second_future});    
+                }
+                FlattenFuture::EvalSecond { second_future } => {
+                    match ready!(second_future.try_poll(cx)) {
+                        Ok(item) => return Poll::Ready(Ok(item)),
+                        Err(e) => return Poll::Ready(Err(e)),
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,6 +1,7 @@
 mod and;
 mod and_then;
 mod boxed;
+mod flatten;
 mod map;
 mod map_err;
 mod or;
@@ -10,7 +11,6 @@ pub(crate) mod service;
 mod unify;
 mod untuple_one;
 mod wrap;
-mod flatten;
 
 use std::future::Future;
 use std::pin::Pin;
@@ -24,10 +24,10 @@ use crate::route::{self, Route};
 pub(crate) use self::and::And;
 use self::and_then::AndThen;
 pub use self::boxed::BoxedFilter;
+use self::flatten::Flatten;
 pub(crate) use self::map::Map;
 pub(crate) use self::map_err::MapErr;
 pub(crate) use self::or::Or;
-use self::flatten::Flatten;
 use self::or_else::OrElse;
 use self::recover::Recover;
 use self::unify::Unify;
@@ -253,7 +253,7 @@ pub trait Filter: FilterBase {
     ///         my_complex_filter
     ///     });
     /// ```
-    fn flatten<F>(self, fun: F) -> Flatten<Self, F> 
+    fn flatten<F>(self, fun: F) -> Flatten<Self, F>
     where
         Self: Sized,
         F: Func<Self::Extract> + Clone + Send,

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod service;
 mod unify;
 mod untuple_one;
 mod wrap;
+mod flatten;
 
 use std::future::Future;
 use std::pin::Pin;
@@ -26,6 +27,7 @@ pub use self::boxed::BoxedFilter;
 pub(crate) use self::map::Map;
 pub(crate) use self::map_err::MapErr;
 pub(crate) use self::or::Or;
+use self::flatten::Flatten;
 use self::or_else::OrElse;
 use self::recover::Recover;
 use self::unify::Unify;
@@ -226,6 +228,20 @@ pub trait Filter: FilterBase {
         <F::Output as TryFuture>::Error: CombineRejection<Self::Error>,
     {
         AndThen {
+            filter: self,
+            callback: fun,
+        }
+    }
+
+    /// TODO
+    fn flatten<F>(self, fun: F) -> Flatten<Self, F> 
+    where
+        Self: Sized,
+        F: Func<Self::Extract> + Clone + Send,
+        F::Output: Future + Send,
+        <F::Output as Future>::Output: Filter<Error = Self::Error>,
+    {
+        Flatten {
             filter: self,
             callback: fun,
         }

--- a/tests/filter.rs
+++ b/tests/filter.rs
@@ -146,6 +146,23 @@ async fn unify() {
     assert_eq!(ex, 1);
 }
 
+#[tokio::test]
+async fn flatten() {
+    let a = warp::path::param::<u32>();
+    let b = a.flatten(|v| async move {
+        if v == 1 {
+            warp::path::param::<u32>().boxed()
+        } else {
+            warp::path::param::<u32>().map(|x| x * 2).boxed()
+        }
+    });
+
+    let ex1 = warp::test::request().path("/1/2").filter(&b).await.unwrap();
+    assert_eq!(ex1, 2);
+    let ex2 = warp::test::request().path("/3/2").filter(&b).await.unwrap();
+    assert_eq!(ex2, 4);
+}
+
 #[should_panic]
 #[tokio::test]
 async fn nested() {


### PR DESCRIPTION
At this point in time, there isn't anyway to compose filters dynamically. You can decide to append dynamic async code to the end of a filter chain through `.and_then()`, but all the implementation after that point must be known before the request is being processed.

This function allows you to compose a function on the end of a filter which itself yields a new filter. This composition has the extract/error types of the yielded filter, and can be further composed.

FWIW, I'm not 100% sure that "flatten" is the right name, given that in futures, this is applied to a Future that yields a Future. I can change the implementation to do that (and then just use `and_then()` to do the composition otherwise, but I think the demand for something in this category is there.

My use case came up when I was trying to implement a session middleware in pure warp. This wasn't possible, because I couldn't create a filter that could obtain the session data, and pass into the next stage of a filter.