### PR TITLE
Remove Content-Length header when using a compression filter

### DIFF
--- a/src/filters/compression.rs
+++ b/src/filters/compression.rs
@@ -4,7 +4,10 @@
 
 use async_compression::stream::{BrotliEncoder, DeflateEncoder, GzipEncoder};
 use http::header::HeaderValue;
-use hyper::{header::CONTENT_ENCODING, Body};
+use hyper::{
+    header::{CONTENT_ENCODING, CONTENT_LENGTH},
+    Body,
+};
 
 use crate::filter::{Filter, WrapSealed};
 use crate::reject::IsReject;
@@ -58,6 +61,7 @@ pub fn gzip() -> Compression<impl Fn(CompressionProps) -> Response + Copy> {
             .head
             .headers
             .append(CONTENT_ENCODING, CompressionAlgo::GZIP.into());
+        props.head.headers.remove(CONTENT_LENGTH);
         Response::from_parts(props.head, body)
     };
     Compression { func }
@@ -83,6 +87,7 @@ pub fn deflate() -> Compression<impl Fn(CompressionProps) -> Response + Copy> {
             .head
             .headers
             .append(CONTENT_ENCODING, CompressionAlgo::DEFLATE.into());
+        props.head.headers.remove(CONTENT_LENGTH);
         Response::from_parts(props.head, body)
     };
     Compression { func }
@@ -108,6 +113,7 @@ pub fn brotli() -> Compression<impl Fn(CompressionProps) -> Response + Copy> {
             .head
             .headers
             .append(CONTENT_ENCODING, CompressionAlgo::BR.into());
+        props.head.headers.remove(CONTENT_LENGTH);
         Response::from_parts(props.head, body)
     };
     Compression { func }


### PR DESCRIPTION
The Content-Length header should represent the length of the compressed data, which we can't compute ahead of time for streamed bodies.

[The header is set when using the `dir` filter](https://github.com/seanmonstar/warp/blob/master/src/filters/fs.rs#L305), which means that combining the `dir` and `compression::*` filters will result in invalid responses. In my case, this caused some JavaScript files to be non-deterministically erroneously loaded in Chrome. `curl` also complains:

```
curl: (18) transfer closed with 3614 bytes remaining to read
```

I don't think this is the best implementation, but it is probably the simplest. A better way to do this would be to differentiate between sized and non-sized bodies later down the pipeline and only add the Content-Length header when possible/computable.

Prior art:
* Express https://github.com/expressjs/compression/blob/master/index.js#L202
