### PR TITLE
html() now returns the Html struct instead of impl Reply

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -165,7 +165,7 @@ impl StdError for ReplyJsonError {}
 ///         warp::reply::html(body)
 ///     });
 /// ```
-pub fn html<T>(body: T) -> impl Reply
+pub fn html<T>(body: T) -> Html<T>
 where
     Body: From<T>,
     T: Send,
@@ -173,8 +173,9 @@ where
     Html { body }
 }
 
+/// An HTML reply.
 #[allow(missing_debug_implementations)]
-struct Html<T> {
+pub struct Html<T> {
     body: T,
 }
 


### PR DESCRIPTION
This should allow better `and_then()` composition using warp::reply::html() as was discussed on the tokio Discord.