### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tower-service = "0.3"
 # tls is enabled by default, we don't want that yet
 tokio-tungstenite = { version = "0.10", default-features = false, optional = true }
 urlencoding = "1.0.0"
-pin-project = "0.4.5"
+pin-project = "0.4.17"
 tokio-rustls = { version = "0.13.1", optional = true }
 
 [dev-dependencies]

--- a/src/filter/and.rs
+++ b/src/filter/and.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures::ready;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 use super::{Combine, Filter, FilterBase, HList, Internal, Tuple};
 use crate::reject::CombineRejection;
@@ -41,7 +41,7 @@ pub struct AndFuture<T: Filter, U: Filter> {
     state: State<T, U>,
 }
 
-#[pin_project]
+#[pin_project(project = StateProj)]
 enum State<T: Filter, U: Filter> {
     First(#[pin] T::Future, U),
     Second(Option<T::Extract>, #[pin] U::Future),
@@ -59,17 +59,15 @@ where
             <<<T::Extract as Tuple>::HList as Combine<<U::Extract as Tuple>::HList>>::Output as HList>::Tuple,
         <U::Error as CombineRejection<T::Error>>::One>;
 
-    #[project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         loop {
             let pin = self.as_mut().project();
-            #[project]
             let (ex1, fut2) = match pin.state.project() {
-                State::First(first, second) => match ready!(first.poll(cx)) {
+                StateProj::First(first, second) => match ready!(first.poll(cx)) {
                     Ok(first) => (first, second.filter(Internal)),
                     Err(err) => return Poll::Ready(Err(From::from(err))),
                 },
-                State::Second(ex1, second) => {
+                StateProj::Second(ex1, second) => {
                     let ex2 = match ready!(second.poll(cx)) {
                         Ok(second) => second,
                         Err(err) => return Poll::Ready(Err(From::from(err))),
@@ -78,7 +76,7 @@ where
                     self.set(AndFuture { state: State::Done });
                     return Poll::Ready(Ok(ex3));
                 }
-                State::Done => panic!("polled after complete"),
+                StateProj::Done => panic!("polled after complete"),
             };
 
             self.set(AndFuture {

--- a/src/filter/or_else.rs
+++ b/src/filter/or_else.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures::{ready, TryFuture};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 use super::{Filter, FilterBase, Func, Internal};
 use crate::reject::IsReject;
@@ -48,7 +48,7 @@ where
     original_path_index: PathIndex,
 }
 
-#[pin_project]
+#[pin_project(project = StateProj)]
 enum State<T, F>
 where
     T: Filter,
@@ -77,17 +77,15 @@ where
 {
     type Output = Result<<F::Output as TryFuture>::Ok, <F::Output as TryFuture>::Error>;
 
-    #[project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         loop {
             let pin = self.as_mut().project();
-            #[project]
             let (err, second) = match pin.state.project() {
-                State::First(first, second) => match ready!(first.try_poll(cx)) {
+                StateProj::First(first, second) => match ready!(first.try_poll(cx)) {
                     Ok(ex) => return Poll::Ready(Ok(ex)),
                     Err(err) => (err, second),
                 },
-                State::Second(second) => {
+                StateProj::Second(second) => {
                     let ex2 = ready!(second.try_poll(cx));
                     self.set(OrElseFuture {
                         state: State::Done,
@@ -95,7 +93,7 @@ where
                     });
                     return Poll::Ready(ex2);
                 }
-                State::Done => panic!("polled after complete"),
+                StateProj::Done => panic!("polled after complete"),
             };
 
             pin.original_path_index.reset_path();


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*
