### PR TITLE
reject_redirect for trailing slash

### DIFF
--- a/examples/rejections.rs
+++ b/examples/rejections.rs
@@ -66,6 +66,9 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
     if err.is_not_found() {
         code = StatusCode::NOT_FOUND;
         message = "NOT_FOUND";
+    } else if err.is_rejected_redirected() {
+        code = StatusCode::MOVED_PERMANENTLY;
+        message = "MOVED_PERMANENTLY";
     } else if let Some(DivideByZero) = err.find() {
         code = StatusCode::BAD_REQUEST;
         message = "DIVIDE_BY_ZERO";

--- a/examples/trailing_slash_or_redirect.rs
+++ b/examples/trailing_slash_or_redirect.rs
@@ -1,0 +1,18 @@
+#![deny(warnings)]
+use warp::Filter;
+
+#[tokio::main]
+async fn main() {
+    // Match foo/bar and foo/bar/  - mandatory trailing slash
+    // Match foo/bar_2 and foo/bar_2/  - not mandatory trailing slash
+    //
+    // in the first route  trailing slash is mandatory
+    // if there is no trailing slash, returns reject redirect to same uri with trailing slash
+    // in the second route the trailing slash is not mandatory
+    let routes = warp::path!("foo" / "bar")
+        .and(warp::path::trailing_slash_or_redirect())
+        .map(|| "foo bar")
+        .or(warp::path!("foo" / "bar_2").map(|| "foo bar_2"));
+
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+}

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -392,3 +392,28 @@ async fn peek_segments() {
     let segs = ex.segments().collect::<Vec<_>>();
     assert_eq!(segs, Vec::<&str>::new());
 }
+
+#[tokio::test]
+async fn trailing_slash_or_redirect() {
+    // /foo/bar reject redirects to /foo/bar/
+    let result = warp::test::request()
+        .path("/foo/bar")
+        .filter(&warp::path::trailing_slash_or_redirect())
+        .await;
+
+    match result {
+        Ok(x) => assert_eq!(format!("{:?}", x), "unexpected"),
+        Err(reject) => assert_eq!(format!("{:?}", reject), "Rejection(/foo/bar/)"),
+    }
+
+    // /foo/bar/ is NOT redirected
+    let result = warp::test::request()
+        .path("/foo/bar/")
+        .filter(&warp::path::trailing_slash_or_redirect())
+        .await;
+
+    match result {
+        Ok(x) => assert_eq!(format!("{:?}", x), "()"),
+        Err(reject) => assert_eq!(format!("{:?}", reject), "unexpected"),
+    }
+}


### PR DESCRIPTION
This PR is to show the idea how to introduce reject redirect.
That is useful for the problem of trailing slash described in this issue:
https://github.com/seanmonstar/warp/issues/584

Please, review the changes.
I used the not_found reject Reason as a template.
I added tests and examples.