### PR TITLE
(not_)end_with_trailing_slash_or_redirect

### DIFF
--- a/examples/trailing_slash.rs
+++ b/examples/trailing_slash.rs
@@ -1,0 +1,52 @@
+#![deny(warnings)]
+
+use warp::Filter;
+
+// trailing slash on some routes are mandatory, on others are forbidden
+// in case of wrong request it is then redirected to the correct one.
+
+// after running this example server:
+// clear; cargo run --example trailing_slash
+
+// run this curl commands or open in browser:
+// reply ok
+// clear; curl -i http://127.0.0.1:3030/foo/slash_1/; echo
+// clear; curl -i http://127.0.0.1:3030/foo/no_slash_2; echo
+// clear; curl -i http://127.0.0.1:3030/foo/slash_3/; echo
+// clear; curl -i http://127.0.0.1:3030/foo/no_slash_4; echo
+
+// moved permanently redirect
+// clear; curl -i http://127.0.0.1:3030/foo/slash_1; echo
+// clear; curl -i http://127.0.0.1:3030/foo/no_slash_2/; echo
+// clear; curl -i http://127.0.0.1:3030/foo/slash_3; echo
+// clear; curl -i http://127.0.0.1:3030/foo/no_slash_4/; echo
+
+#[tokio::main]
+async fn main() {
+    pretty_env_logger::init();
+
+    // the special character ! in the end of path!() means
+    // that the request will be redirected if the trailing slash is missing
+    // this is a recommended solution for "mandatory trailing slash"
+    let route1 = warp::path!( "foo" / "slash_1" / ! ).map(|| "slash_1 ok");
+    // the special symbol < in the end of path!() means
+    // that the request will be redirected if the trailing slash is present
+    // some website need this for historical reasons
+    let route2 = warp::path!( "foo" / "no_slash_2" / < ).map(|| "no_slash_2 ok");
+
+    let route3 = warp::path::path("foo")
+        .and(warp::path::path("slash_3"))
+        .and(warp::path::redirect_if_not_trailing_slash())
+        .and(warp::path::end())
+        .map(|| warp::reply::html("slash_3 ok"));
+
+    let route4 = warp::path::path("foo")
+        .and(warp::path::path("no_slash_4"))
+        .and(warp::path::redirect_if_has_trailing_slash())
+        .and(warp::path::end())
+        .map(|| warp::reply::html("no_slash_4 ok"));
+
+    let routes = route1.or(route2).or(route3).or(route4);
+
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await
+}

--- a/examples/trailing_slash2.rs
+++ b/examples/trailing_slash2.rs
@@ -1,0 +1,39 @@
+#![deny(warnings)]
+
+use warp::Filter;
+
+// testing if
+// "in the event of a rejection will still go through the filter chain"
+// I put a println!() in the redirect_if_not_trailing_slash().
+// I declared the same routes 2 times.
+// If it "goes through the chain" it must println!() 2 times for the same route.
+
+// run this example web server:
+// clear; cargo run --example trailing_slash2
+
+// run this curl commands or open in browser:
+// clear; curl -i http://127.0.0.1:3030/foo/slash_1/; echo
+// clear; curl -i http://127.0.0.1:3030/foo/slash_2/; echo
+
+// The result is convincing:
+// Running `target/debug/examples/trailing_slash2`
+// redirect_if_not_trailing_slash /foo/slash_1/
+// redirect_if_not_trailing_slash /foo/slash_2/
+// It does NOT repeat the println!().
+// It means it does not "go through the chain".
+// It stops the chain, when the redirect reply is sent.
+// This is because this rejection is handled.
+
+#[tokio::main]
+async fn main() {
+    pretty_env_logger::init();
+
+    let route1 = warp::path!( "foo" / "slash_1" / ! ).map(|| "slash_1 ok");
+    let route2 = warp::path!( "foo" / "slash_2" / ! ).map(|| "slash_2 ok");
+    let route3 = warp::path!( "foo" / "slash_1" / ! ).map(|| "slash_1 ok");
+    let route4 = warp::path!( "foo" / "slash_2" / ! ).map(|| "slash_2 ok");
+
+    let routes = route1.or(route2).or(route3).or(route4);
+
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await
+}

--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -262,6 +262,7 @@ pub fn end() -> impl Filter<Extract = (), Error = Rejection> + Copy {
 pub fn redirect_if_not_trailing_slash() -> impl Filter<Extract = (), Error = Rejection> + Copy {
     filter_fn(move |route| {
         let path = route.uri().to_string();
+        println!("redirect_if_not_trailing_slash() {}", path);
         // the trailing slash rules don't apply to the website root
         if !path.is_empty() && path != "/" && !path.ends_with("/") {
             log::debug!(


### PR DESCRIPTION
This PR shows the idea to introduce the filter end_with_trailing_slash_or_redirect().
That is useful for the problem of trailing slash described in this issue:
#584
I added tests and examples. They are informative.

I used warp::path::end() as a starting point to build
`warp::path::end_with_trailing_slash_or_redirect()`
It works just like path::end(), except when the trailing slash is missing.
Then it redirects with a reject Reason::Other Known 301 MOVED_PERMANENTLY.
The path must have at least one segment.

I was thinking about a filter to only detect trailing slash and leave developers to deal with it,
but I didn't see any other use-case than this with a redirect. This is the recommended solution.
So it looked to me unnecessary to split the slash detection and the redirect action.
I think that end_with_trailing_slash_or_redirect() could be added to the macro path!().
If the invocation ends with /, then use end_with_trailing_slash_or_redirect() instead of end().
