### PR TITLE
dir trailing slash

### DIFF
--- a/examples/dir.rs
+++ b/examples/dir.rs
@@ -1,5 +1,18 @@
 #![deny(warnings)]
 
+// trailing slash on directories is mandatory.
+// In case of wrong request, it is then redirected to the correct one.
+
+// after running this server,
+// clear; cargo run --example dir
+// run this curl commands
+
+// reply ok
+// clear; curl -i http://127.0.0.1:3030/sub-dir1/; echo
+
+// moved permanently redirect
+// clear; curl -i http://127.0.0.1:3030/sub-dir1; echo
+
 #[tokio::main]
 async fn main() {
     pretty_env_logger::init();

--- a/examples/dir/sub-dir1/another.html
+++ b/examples/dir/sub-dir1/another.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>dir/sub-dir1/another.html</title>
+    </head>
+    <body>
+        <h1>Welcome to Another Page 1</h1>
+        <a href="/">home</a>
+    </body>
+</html>

--- a/examples/dir/sub-dir1/index.html
+++ b/examples/dir/sub-dir1/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>/sub-dir1/index.html</title>
+    </head>
+    <body>
+        <h1>Welcome to /sub-dir1/index.html</h1>
+
+        <h1>The problem of trailing slash - a subtle problem</h1>
+        <p>If the URL does not include the filename, but only the directory, the server will return the default index.html file of that sub-dir.</p>
+        <p>It is not a 301 redirect, this action is taken quietly by the server. The browser knows nothing about that.</p>
+        <p>But the URL for sub-dir can be ambiguous. It can have or not have the trailing slash.</p>
+        <p>1st example: /sub-dir1/</p>
+        <p>2nd example: /sub-dir1</p>
+        <p>Both of these will open the same page /sub-dir/index.html and it looks fine.</p>
+        <H1>But</H1>
+        <p>If this page contains relative links, these 2 examples will behave differently !</p>
+        <p>For example this relative link:</p>
+        <p><a href="another.html">another.html</a></p>
+        <p>The 1st example (trailing slash) will open the page: /sub-dir1/another.html. This is expected.</p>
+        <p>The 2nd example (not trailing slash) would open the page: /another.html. What? How?</p>
+        <p>The story goes that the browser joined '/sub-dir1' and 'another.html'.</p>
+        <p>The browser doesn't know that sub-dir1 is a dir. Without the trailing slash, it looks just like a normal file.</p>
+        <p>And it joined this relative link in an unexpected way.</p>
+        <p>It is recommended that the sub-dirs always have the trailing slash.</p>
+        <p>If the server recognize a directory and finds the URL missing the trailing slash, it sends a 301 redirect response to the correct URL.</p>
+        <h1>The behavior of relative links</h1>
+        <h2>same folder</h2>
+        <p><a href="another.html">another.html</a></p>
+        <h2>parent folder</h2>
+        <p><a href="..">..</a></p>
+        <p><a href="../">../</a></p>
+        <p><a href="../index.html">../index.html</a></p>
+        <p><a href="../another.html">../another.html</a></p>
+        <h2>child folder</h2>
+        <p><a href="sub-dir2">sub-dir2</a></p>
+        <p><a href="sub-dir2/">sub-dir2/</a></p>
+        <p><a href="sub-dir2/index.html">sub-dir2/index.html</a></p>
+        <p><a href="sub-dir2/another.html">sub-dir2/another.html</a></p>
+    </body>
+</html>

--- a/examples/dir/sub-dir1/sub-dir2/another.html
+++ b/examples/dir/sub-dir1/sub-dir2/another.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>dir/sub-dir1/sub-dir2/another.html</title>
+    </head>
+    <body>
+        <h1>Welcome to Another Page 2</h1>
+        <a href="/">home</a>
+    </body>
+</html>

--- a/examples/dir/sub-dir1/sub-dir2/index.html
+++ b/examples/dir/sub-dir1/sub-dir2/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>dir/sub-dir1/sub-dir2/index.html</title>
+    </head>
+    <body>
+        <h1>Welcome to /sub-dir1/sub-dir2/index.html</h1>
+        <h1>relative links</h1>
+        <h2>same folder</h2>
+        <p><a href="another.html">another.html</a></p>
+        <h2>parent folder</h2>
+        <p><a href="..">..</a></p>
+        <p><a href="../">../</a></p>
+        <p><a href="../index.html">../index.html</a></p>
+        <p><a href="../another.html">../another.html</a></p>
+        <h2>parent parent folder</h2>
+        <p><a href="../..">../..</a></p>
+        <p><a href="../../">../../</a></p>
+        <p><a href="../../index.html">../../index.html</a></p>
+        <p><a href="../../another.html">../../another.html</a></p>
+    </body>
+</html>

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -105,11 +105,12 @@ async fn dir_fallback_index_on_dir() {
     let file = warp::fs::dir("examples");
     let req = warp::test::request().path("/dir");
     let res = req.reply(&file).await;
-    let contents = fs::read("examples/dir/index.html").expect("fs::read");
-    assert_eq!(res.headers()["content-length"], contents.len().to_string());
-    assert_eq!(res.status(), 200);
+    assert_eq!(res.headers()["location"], "/dir/");
+    assert_eq!(res.status(), 301);
+
     let req = warp::test::request().path("/dir/");
     let res = req.reply(&file).await;
+    let contents = fs::read("examples/dir/index.html").expect("fs::read");
     assert_eq!(res.headers()["content-length"], contents.len().to_string());
     assert_eq!(res.status(), 200);
 }


### PR DESCRIPTION
I opened this Pull Request to discuss how to solve the problem of trailing slash inside the `dir Filter`.
Here are the steps to reproduce the subtle problem.
Inside the /sub-dir1/index.html the problem is explained thoroughly. 
My earlier PR for https://github.com/seanmonstar/warp/pull/602 (not_)end_with_trailing_slash_or_redirect is not applicable here.

Run original example:
`$ clear; cargo run --example dir`
Open browser on
<http://127.0.0.1:3030/sub-dir1>
Note that there is NO traiing slash !
Try the relative link to `another.html`.
It does not work as expected. It opens:
<http://127.0.0.1:3030/another.html>

Run the new example with the proposed new code:
`$ clear; cargo run --example dir_ends_with_trailing_slash_or_redirect`
Open browser on the same url without trailing slash:
<http://127.0.0.1:3030/sub-dir1>
It will be automatically redirected to:
http://127.0.0.1:3030/sub-dir1/
Now the relative link to another.html works as expected:
<http://127.0.0.1:3030/sub-dir1/another.html>

