### PR TITLE
Add Cause for BodyDeserializeError and update Rejections example

### DIFF
--- a/examples/rejections.rs
+++ b/examples/rejections.rs
@@ -69,6 +69,16 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
     } else if let Some(DivideByZero) = err.find() {
         code = StatusCode::BAD_REQUEST;
         message = "DIVIDE_BY_ZERO";
+    } else if let Some(e) = err.find::<warp::filters::body::BodyDeserializeError>() {
+        // This error happens if the body could not be deserialized correctly
+        // We can use the cause to analyze the error and customize the error message
+        let cause = e.cause();
+        if cause.to_string().contains("someField") {
+            message = "FIELD_ERROR: someField"
+        } else {
+            message = "BAD_REQUEST";
+        }
+        code = StatusCode::BAD_REQUEST;
     } else if let Some(_) = err.find::<warp::reject::MethodNotAllowed>() {
         // We can handle a specific error, here METHOD_NOT_ALLOWED,
         // and render it however we want

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -325,6 +325,13 @@ impl fmt::Display for BodyDeserializeError {
 
 impl StdError for BodyDeserializeError {}
 
+impl BodyDeserializeError {
+    /// Access the cause of the deserialization error
+    pub fn cause(&self) -> &BoxError {
+        &self.cause
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct BodyReadError(::hyper::Error);
 

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -323,12 +323,9 @@ impl fmt::Display for BodyDeserializeError {
     }
 }
 
-impl StdError for BodyDeserializeError {}
-
-impl BodyDeserializeError {
-    /// Access the cause of the deserialization error
-    pub fn cause(&self) -> &BoxError {
-        &self.cause
+impl StdError for BodyDeserializeError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(self.cause.as_ref())
     }
 }
 


### PR DESCRIPTION
PR for the issue #650 

Adds a `.cause()` method for `BodyDeserializeError`, so the underlying cause can be used to handle the error properly.

Also adds a small update to the `rejections.rs` example to showcase it.