### PR TITLE
Add path getter for File Reply

### DIFF
--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -212,6 +212,32 @@ fn conditionals() -> impl Filter<Extract = One<Conditionals>, Error = Infallible
 #[derive(Debug)]
 pub struct File {
     resp: Response,
+    path: ArcPath,
+}
+
+impl File {
+    /// Extract the `&Path` of the file this `Response` delivers.
+    ///
+    /// # Example
+    ///
+    /// The example below changes the Content-Type response header for every file called `video.mp4`.
+    ///
+    /// ```
+    /// use warp::{Filter, reply::Reply};
+    ///
+    /// let route = warp::path("static")
+    ///     .and(warp::fs::dir("/www/static"))
+    ///     .map(|reply: warp::filters::fs::File| {
+    ///         if reply.path().ends_with("video.mp4") {
+    ///             warp::reply::with_header(reply, "Content-Type", "video/mp4").into_response()
+    ///         } else {
+    ///             reply.into_response()
+    ///         }
+    ///     });
+    /// ```
+    pub fn path<'a>(&'a self) -> &'a Path {
+        self.path.as_ref()
+    }
 }
 
 // Silly wrapper since Arc<PathBuf> doesn't implement AsRef<Path> ;_;
@@ -323,7 +349,7 @@ fn file_conditional(
             }
         };
 
-        File { resp }
+        File { resp, path }
     })
 }
 

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -235,7 +235,7 @@ impl File {
     ///         }
     ///     });
     /// ```
-    pub fn path<'a>(&'a self) -> &'a Path {
+    pub fn path(&self) -> &Path {
         self.path.as_ref()
     }
 }


### PR DESCRIPTION
#648 requires a way to retrieve the file path from a `File` reply. This PR implements such a getter by storing the `ArcPath` in the `File` struct and providing a reference to it. The documentation shows an example use-case where the `Content-Type` header is changed based on the filename.