### PR TITLE
Make MissingConnectionUpgrade public 

### DIFF
--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -363,8 +363,9 @@ impl Into<Vec<u8>> for Message {
 
 // ===== Rejections =====
 
+/// Connection header did not include 'upgrade'
 #[derive(Debug)]
-pub(crate) struct MissingConnectionUpgrade;
+pub struct MissingConnectionUpgrade;
 
 impl ::std::fmt::Display for MissingConnectionUpgrade {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {


### PR DESCRIPTION
Addresses #653. Given that other `Known` rejections are public, `MissingConnectionUpgrade` should be as well.