### PR TITLE
Migrate internal diagnostics to `tracing`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.6"
 tokio = { version = "0.2", features = ["fs", "stream", "sync", "time"] }
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
+tracing-futures = { version = "0.2", default-features = false, features = ["std-future"] }
 tower-service = "0.3"
 # tls is enabled by default, we don't want that yet
 tokio-tungstenite = { version = "0.10", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.6"
 tokio = { version = "0.2", features = ["fs", "stream", "sync", "time"] }
+tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 tower-service = "0.3"
 # tls is enabled by default, we don't want that yet
 tokio-tungstenite = { version = "0.10", default-features = false, optional = true }

--- a/src/filter/service.rs
+++ b/src/filter/service.rs
@@ -129,7 +129,7 @@ where
             Poll::Ready(Ok(ok)) => Poll::Ready(Ok(ok.into_response())),
             Poll::Pending => Poll::Pending,
             Poll::Ready(Err(err)) => {
-                log::debug!("rejected: {:?}", err);
+                tracing::debug!("rejected: {:?}", err);
                 Poll::Ready(Ok(err.into_response()))
             }
         }

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -28,7 +28,7 @@ type BoxError = Box<dyn StdError + Send + Sync>;
 pub(crate) fn body() -> impl Filter<Extract = (Body,), Error = Rejection> + Copy {
     filter_fn_one(|route| {
         future::ready(route.take_body().ok_or_else(|| {
-            log::error!("request body already taken in previous filter");
+            tracing::error!("request body already taken in previous filter");
             reject::known(BodyConsumedMultipleTimes { _p: () })
         }))
     })
@@ -51,14 +51,14 @@ pub(crate) fn body() -> impl Filter<Extract = (Body,), Error = Rejection> + Copy
 pub fn content_length_limit(limit: u64) -> impl Filter<Extract = (), Error = Rejection> + Copy {
     crate::filters::header::header2()
         .map_err(crate::filter::Internal, |_| {
-            log::debug!("content-length missing");
+            tracing::debug!("content-length missing");
             reject::length_required()
         })
         .and_then(move |ContentLength(length)| {
             if length <= limit {
                 future::ok(())
             } else {
-                log::debug!("content-length: {} is over limit {}", length, limit);
+                tracing::debug!("content-length: {} is over limit {}", length, limit);
                 future::err(reject::payload_too_large())
             }
         })
@@ -106,7 +106,7 @@ pub fn stream(
 pub fn bytes() -> impl Filter<Extract = (Bytes,), Error = Rejection> + Copy {
     body().and_then(|body: hyper::Body| {
         hyper::body::to_bytes(body).map_err(|err| {
-            log::debug!("to_bytes error: {}", err);
+            tracing::debug!("to_bytes error: {}", err);
             reject::known(BodyReadError(err))
         })
     })
@@ -144,7 +144,7 @@ pub fn bytes() -> impl Filter<Extract = (Bytes,), Error = Rejection> + Copy {
 pub fn aggregate() -> impl Filter<Extract = (impl Buf,), Error = Rejection> + Copy {
     body().and_then(|body: ::hyper::Body| {
         hyper::body::aggregate(body).map_err(|err| {
-            log::debug!("aggregate error: {}", err);
+            tracing::debug!("aggregate error: {}", err);
             reject::known(BodyReadError(err))
         })
     })
@@ -175,7 +175,7 @@ pub fn json<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error =
         .and(aggregate())
         .and_then(|buf| async move {
             Json::decode(buf).map_err(|err| {
-                log::debug!("request json body error: {}", err);
+                tracing::debug!("request json body error: {}", err);
                 reject::known(BodyDeserializeError { cause: err })
             })
         })
@@ -210,7 +210,7 @@ pub fn form<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error =
         .and(aggregate())
         .and_then(|buf| async move {
             Form::decode(buf).map_err(|err| {
-                log::debug!("request form body error: {}", err);
+                tracing::debug!("request form body error: {}", err);
                 reject::known(BodyDeserializeError { cause: err })
             })
         })
@@ -254,7 +254,7 @@ fn is_content_type<D: Decode>() -> impl Filter<Extract = (), Error = Rejection> 
     filter_fn(move |route| {
         let (type_, subtype) = D::MIME;
         if let Some(value) = route.headers().get(CONTENT_TYPE) {
-            log::trace!("is_content_type {}/{}? {:?}", type_, subtype, value);
+            tracing::trace!("is_content_type {}/{}? {:?}", type_, subtype, value);
             let ct = value
                 .to_str()
                 .ok()
@@ -263,7 +263,7 @@ fn is_content_type<D: Decode>() -> impl Filter<Extract = (), Error = Rejection> 
                 if ct.type_() == type_ && ct.subtype() == subtype {
                     future::ok(())
                 } else {
-                    log::debug!(
+                    tracing::debug!(
                         "content-type {:?} doesn't match {}/{}",
                         value,
                         type_,
@@ -272,15 +272,15 @@ fn is_content_type<D: Decode>() -> impl Filter<Extract = (), Error = Rejection> 
                     future::err(reject::unsupported_media_type())
                 }
             } else {
-                log::debug!("content-type {:?} couldn't be parsed", value);
+                tracing::debug!("content-type {:?} couldn't be parsed", value);
                 future::err(reject::unsupported_media_type())
             }
         } else if D::WITH_NO_CONTENT_TYPE {
             // Optimistically assume its correct!
-            log::trace!("no content-type header, assuming {}/{}", type_, subtype);
+            tracing::trace!("no content-type header, assuming {}/{}", type_, subtype);
             future::ok(())
         } else {
-            log::debug!("no content-type found");
+            tracing::debug!("no content-type found");
             future::err(reject::unsupported_media_type())
         }
     })

--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -368,7 +368,9 @@ impl Configured {
                         return Err(Forbidden::MethodNotAllowed);
                     }
                 } else {
-                    log::trace!("preflight request missing access-control-request-method header");
+                    tracing::trace!(
+                        "preflight request missing access-control-request-method header"
+                    );
                     return Err(Forbidden::MethodNotAllowed);
                 }
 
@@ -388,7 +390,7 @@ impl Configured {
             (Some(origin), _) => {
                 // Any other method, simply check for a valid origin...
 
-                log::trace!("origin header: {:?}", origin);
+                tracing::trace!("origin header: {:?}", origin);
                 if self.is_origin_allowed(origin) {
                     Ok(Validated::Simple(origin.clone()))
                 } else {

--- a/src/filters/header.rs
+++ b/src/filters/header.rs
@@ -38,7 +38,7 @@ pub fn header<T: FromStr + Send + 'static>(
     name: &'static str,
 ) -> impl Filter<Extract = One<T>, Error = Rejection> + Copy {
     filter_fn_one(move |route| {
-        log::trace!("header({:?})", name);
+        tracing::trace!("header({:?})", name);
         let route = route
             .headers()
             .get(name)
@@ -52,7 +52,7 @@ pub fn header<T: FromStr + Send + 'static>(
 pub(crate) fn header2<T: Header + Send + 'static>(
 ) -> impl Filter<Extract = One<T>, Error = Rejection> + Copy {
     filter_fn_one(move |route| {
-        log::trace!("header2({:?})", T::name());
+        tracing::trace!("header2({:?})", T::name());
         let route = route
             .headers()
             .typed_get()
@@ -80,7 +80,7 @@ where
     T: FromStr + Send + 'static,
 {
     filter_fn_one(move |route| {
-        log::trace!("optional({:?})", name);
+        tracing::trace!("optional({:?})", name);
         let result = route.headers().get(name).map(|value| {
             value
                 .to_str()
@@ -110,7 +110,7 @@ where
     T: Header + PartialEq + Clone + Send,
 {
     filter_fn(move |route| {
-        log::trace!("exact2({:?})", T::NAME);
+        tracing::trace!("exact2({:?})", T::NAME);
         route.headers()
             .typed_get::<T>()
             .and_then(|val| if val == header {
@@ -139,7 +139,7 @@ pub fn exact(
     value: &'static str,
 ) -> impl Filter<Extract = (), Error = Rejection> + Copy {
     filter_fn(move |route| {
-        log::trace!("exact?({:?}, {:?})", name, value);
+        tracing::trace!("exact?({:?}, {:?})", name, value);
         let route = route
             .headers()
             .get(name)
@@ -171,7 +171,7 @@ pub fn exact_ignore_case(
     value: &'static str,
 ) -> impl Filter<Extract = (), Error = Rejection> + Copy {
     filter_fn(move |route| {
-        log::trace!("exact_ignore_case({:?}, {:?})", name, value);
+        tracing::trace!("exact_ignore_case({:?}, {:?})", name, value);
         let route = route
             .headers()
             .get(name)
@@ -203,7 +203,7 @@ pub fn value(
     name: &'static str,
 ) -> impl Filter<Extract = One<HeaderValue>, Error = Rejection> + Copy {
     filter_fn_one(move |route| {
-        log::trace!("value({:?})", name);
+        tracing::trace!("value({:?})", name);
         let route = route
             .headers()
             .get(name)

--- a/src/filters/method.rs
+++ b/src/filters/method.rs
@@ -131,7 +131,7 @@ where
 {
     filter_fn(move |route| {
         let method = func();
-        log::trace!("method::{:?}?: {:?}", method, route.method());
+        tracing::trace!("method::{:?}?: {:?}", method, route.method());
         if route.method() == method {
             future::ok(())
         } else {

--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -179,7 +179,7 @@ where
     Exact(Opaque(p))
     /*
     segment(move |seg| {
-        log::trace!("{:?}?: {:?}", p, seg);
+        tracing::trace!("{:?}?: {:?}", p, seg);
         if seg == p {
             Ok(())
         } else {
@@ -209,7 +209,7 @@ where
         route::with(|route| {
             let p = self.0.as_ref();
             future::ready(with_segment(route, |seg| {
-                log::trace!("{:?}?: {:?}", p, seg);
+                tracing::trace!("{:?}?: {:?}", p, seg);
 
                 if seg == p {
                     Ok(())
@@ -266,7 +266,7 @@ pub fn end() -> impl Filter<Extract = (), Error = Rejection> + Copy {
 pub fn param<T: FromStr + Send + 'static>(
 ) -> impl Filter<Extract = One<T>, Error = Rejection> + Copy {
     filter_segment(|seg| {
-        log::trace!("param?: {:?}", seg);
+        tracing::trace!("param?: {:?}", seg);
         if seg.is_empty() {
             return Err(reject::not_found());
         }

--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -14,12 +14,12 @@ pub fn query<T: DeserializeOwned + Send + 'static>(
 ) -> impl Filter<Extract = One<T>, Error = Rejection> + Copy {
     filter_fn_one(|route| {
         let query_string = route.query().unwrap_or_else(|| {
-            log::debug!("route was called without a query string, defaulting to empty");
+            tracing::debug!("route was called without a query string, defaulting to empty");
             ""
         });
 
         let query_encoded = serde_urlencoded::from_str(query_string).map_err(|e| {
-            log::debug!("failed to decode query string '{}': {:?}", query_string, e);
+            tracing::debug!("failed to decode query string '{}': {:?}", query_string, e);
             reject::invalid_query()
         });
         future::ready(query_encoded)

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -231,7 +231,7 @@ impl<T: Serialize> SseFormat for SseJson<T> {
             k.fmt(f)?;
             serde_json::to_string(&self.0)
                 .map_err(|error| {
-                    log::error!("sse::json error {}", error);
+                    tracing::error!("sse::json error {}", error);
                     fmt::Error
                 })
                 .and_then(|data| data.fmt(f))?;
@@ -409,7 +409,7 @@ where
             .event_stream
             .map_err(|error| {
                 // FIXME: error logging
-                log::error!("sse stream error: {}", error);
+                tracing::error!("sse stream error: {}", error);
                 SseError
             })
             .into_stream()
@@ -592,7 +592,7 @@ where
             }
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Ready(Some(Err(error))) => {
-                log::error!("sse::keep error: {}", error);
+                tracing::error!("sse::keep error: {}", error);
                 Poll::Ready(Some(Err(SseError)))
             }
         }

--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -139,13 +139,13 @@ where
             .body
             .on_upgrade()
             .and_then(move |upgraded| {
-                log::trace!("websocket upgrade complete");
+                tracing::trace!("websocket upgrade complete");
                 WebSocket::from_raw_socket(upgraded, protocol::Role::Server, config).map(Ok)
             })
             .and_then(move |socket| on_upgrade(socket).map(Ok))
             .map(|result| {
                 if let Err(err) = result {
-                    log::debug!("ws upgrade error: {}", err);
+                    tracing::debug!("ws upgrade error: {}", err);
                 }
             });
         ::tokio::task::spawn(fut);
@@ -196,11 +196,11 @@ impl Stream for WebSocket {
         match ready!(Pin::new(&mut self.inner).poll_next(cx)) {
             Some(Ok(item)) => Poll::Ready(Some(Ok(Message { inner: item }))),
             Some(Err(e)) => {
-                log::debug!("websocket poll error: {}", e);
+                tracing::debug!("websocket poll error: {}", e);
                 Poll::Ready(Some(Err(crate::Error::new(e))))
             }
             None => {
-                log::trace!("websocket closed");
+                tracing::trace!("websocket closed");
                 Poll::Ready(None)
             }
         }
@@ -221,7 +221,7 @@ impl Sink<Message> for WebSocket {
         match Pin::new(&mut self.inner).start_send(item.inner) {
             Ok(()) => Ok(()),
             Err(e) => {
-                log::debug!("websocket start_send error: {}", e);
+                tracing::debug!("websocket start_send error: {}", e);
                 Err(crate::Error::new(e))
             }
         }
@@ -238,7 +238,7 @@ impl Sink<Message> for WebSocket {
         match ready!(Pin::new(&mut self.inner).poll_close(cx)) {
             Ok(()) => Poll::Ready(Ok(())),
             Err(err) => {
-                log::debug!("websocket close error: {}", err);
+                tracing::debug!("websocket close error: {}", err);
                 Poll::Ready(Err(crate::Error::new(err)))
             }
         }

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -418,7 +418,7 @@ impl Rejections {
                 res
             }
             Rejections::Custom(ref e) => {
-                log::error!(
+                tracing::error!(
                     "unhandled custom rejection, returning 500 response: {:?}",
                     e
                 );

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -105,7 +105,7 @@ where
 {
     Json {
         inner: serde_json::to_vec(val).map_err(|err| {
-            log::error!("reply::json error: {}", err);
+            tracing::error!("reply::json error: {}", err);
         }),
     }
 }
@@ -275,13 +275,13 @@ pub trait Reply: BoxedReply + Send {
                     Reply_(res)
                 },
                 Err(err) => {
-                    log::error!("with_header value error: {}", err.into());
+                    tracing::error!("with_header value error: {}", err.into());
                     Reply_(::reject::server_error()
                         .into_response())
                 }
             },
             Err(err) => {
-                log::error!("with_header name error: {}", err.into());
+                tracing::error!("with_header name error: {}", err.into());
                 Reply_(::reject::server_error()
                     .into_response())
             }
@@ -358,12 +358,14 @@ where
         Ok(name) => match <HeaderValue as TryFrom<V>>::try_from(value) {
             Ok(value) => Some((name, value)),
             Err(err) => {
-                log::error!("with_header value error: {}", err.into());
+                let err = err.into();
+                tracing::error!("with_header value error: {}", err);
                 None
             }
         },
         Err(err) => {
-            log::error!("with_header name error: {}", err.into());
+            let err = err.into();
+            tracing::error!("with_header name error: {}", err);
             None
         }
     };
@@ -418,7 +420,7 @@ where
         match self {
             Ok(t) => t.into_response(),
             Err(e) => {
-                log::error!("reply error: {:?}", e);
+                tracing::error!("reply error: {:?}", e);
                 StatusCode::INTERNAL_SERVER_ERROR.into_response()
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -130,7 +130,7 @@ where
     pub async fn run(self, addr: impl Into<SocketAddr> + 'static) {
         let (addr, fut) = self.bind_ephemeral(addr);
 
-        log::info!("listening on http://{}", addr);
+        tracing::info!("listening on http://{}", addr);
 
         fut.await;
     }
@@ -157,7 +157,7 @@ where
     {
         let fut = self.serve_incoming2(incoming);
 
-        log::info!("listening with custom incoming");
+        tracing::info!("listening with custom incoming");
 
         fut.await;
     }
@@ -183,14 +183,14 @@ where
         let srv = match try_bind!(self, &addr) {
             Ok((_, srv)) => srv,
             Err(err) => {
-                log::error!("error binding to {}: {}", addr, err);
+                tracing::error!("error binding to {}: {}", addr, err);
                 return;
             }
         };
 
         srv.map(|result| {
             if let Err(err) = result {
-                log::error!("server error: {}", err)
+                tracing::error!("server error: {}", err)
             }
         })
         .await;
@@ -211,7 +211,7 @@ where
         let (addr, srv) = bind!(self, addr);
         let srv = srv.map(|result| {
             if let Err(err) = result {
-                log::error!("server error: {}", err)
+                tracing::error!("server error: {}", err)
             }
         });
 
@@ -233,7 +233,7 @@ where
         let (addr, srv) = try_bind!(self, &addr).map_err(crate::Error::new)?;
         let srv = srv.map(|result| {
             if let Err(err) = result {
-                log::error!("server error: {}", err)
+                tracing::error!("server error: {}", err)
             }
         });
 
@@ -281,7 +281,7 @@ where
         let (addr, srv) = bind!(self, addr);
         let fut = srv.with_graceful_shutdown(signal).map(|result| {
             if let Err(err) = result {
-                log::error!("server error: {}", err)
+                tracing::error!("server error: {}", err)
             }
         });
         (addr, fut)
@@ -300,7 +300,7 @@ where
         let (addr, srv) = try_bind!(self, &addr).map_err(crate::Error::new)?;
         let srv = srv.with_graceful_shutdown(signal).map(|result| {
             if let Err(err) = result {
-                log::error!("server error: {}", err)
+                tracing::error!("server error: {}", err)
             }
         });
 
@@ -354,7 +354,7 @@ where
                     .await;
 
             if let Err(err) = srv {
-                log::error!("server error: {}", err);
+                tracing::error!("server error: {}", err);
             }
         }
     }
@@ -373,7 +373,7 @@ where
             .await;
 
         if let Err(err) = srv {
-            log::error!("server error: {}", err);
+            tracing::error!("server error: {}", err);
         }
     }
 
@@ -446,7 +446,7 @@ where
     pub async fn run(self, addr: impl Into<SocketAddr> + 'static) {
         let (addr, fut) = self.bind_ephemeral(addr);
 
-        log::info!("listening on https://{}", addr);
+        tracing::info!("listening on https://{}", addr);
 
         fut.await;
     }
@@ -473,7 +473,7 @@ where
         let (addr, srv) = bind!(tls: self, addr);
         let srv = srv.map(|result| {
             if let Err(err) = result {
-                log::error!("server error: {}", err)
+                tracing::error!("server error: {}", err)
             }
         });
 
@@ -495,7 +495,7 @@ where
 
         let fut = srv.with_graceful_shutdown(signal).map(|result| {
             if let Err(err) = result {
-                log::error!("server error: {}", err)
+                tracing::error!("server error: {}", err)
             }
         });
         (addr, fut)

--- a/src/test.rs
+++ b/src/test.rs
@@ -372,7 +372,7 @@ impl RequestBuilder {
                 let res = match result {
                     Ok(rep) => rep.into_response(),
                     Err(rej) => {
-                        log::debug!("rejected: {:?}", rej);
+                        tracing::debug!("rejected: {:?}", rej);
                         rej.into_response()
                     }
                 };


### PR DESCRIPTION
The `tracing` crate and related libraries provide an interface for Rust
libraries and applications to emit and consume structured, contextual,
and async-aware diagnostic information.  `tracing` is maintained by the
Tokio project and is becoming widely adopted by other libraries in the
stack Warp uses, such as [`hyper`], [`h2`], and [`tonic`] and in [other]
[parts] of the broader Rust ecosystem.

[`tracing` crate]: https://github.com/tokio-rs/tracing
[`hyper`]: https://github.com/hyperium/hyper/pull/2204
[`h2`]: https://github.com/hyperium/h2/pull/475
[`tonic`]: https://github.com/hyperium/tonic/blob/570c606397e47406ec148fe1763586e87a8f5298/tonic/Cargo.toml#L48
[other]: https://github.com/rust-lang/chalk/pull/525
[parts]: https://github.com/rust-lang/compiler-team/issues/331

Tracing supports multiple integrations with the `log` crate. An adapter
can convert `log::Record`s into `tracing::Event`s to be consumed by a
`tracing` subscriber, and a `tracing` feature flag can be enabled to
emit `log` records from `tracing`'s macros. 

However, `tracing`'s system for filtering what spans and events should
be recorded is more efficient than the `log` crate's filtering in many
cases, since it allows filtering decisions to be cached at the callsite,
avoiding a call to a filtering function that may, for example, perform
string matching. This benefit is only available when events are emitted
natively from `tracing`'s macros, rather than converted by an adapter
from `log::Record`s, because `log`'s records lack static callsites.

This branch migrates Warp's internal diagnostics to use `tracing` rather
than `log`. In general, the `tracing` macros are drop-in compatible with
`log`, so the migration only requires changing what crate the macros are
imported from. Tracing's "log" feature flag is enabled, causing all the
`tracing` macros to emit `log` records if no `tracing` subscriber has
been set. This means that the logs currently emitted for `log` users
should be unchanged, while `tracing` users should see small performance
improvements. I've also added a few `tracing` spans to provide context
for some of the events Warp emits.

Future work could involve:
* making the events warp emits more structured, so that they emit 
  `tracing`'s structured key-value fields rather than textual messages
* adding more spans to provide context to Warp's events
* adding filters for emitting traces from applications (PR #656)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>