### PR TITLE
Remove headers from default tracing spans

### DIFF
--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -474,7 +474,7 @@ fn path_and_query(route: &Route) -> PathAndQuery {
 /// Any number of either type identifiers or string expressions can be passed,
 /// each separated by a forward slash (`/`). Strings will be used to match
 /// path segments exactly, and type identifiers are used just like
-/// [`param`](filters::path::param) filters.
+/// [`param`](crate::path::param) filters.
 ///
 /// # Example
 ///

--- a/src/filters/trace.rs
+++ b/src/filters/trace.rs
@@ -60,10 +60,7 @@ pub fn request() -> Trace<impl Fn(Info) -> Span + Clone> {
             span.record("referer", &display(referer));
         }
 
-        // The the headers are, potentially, quite long, so let's record them in
-        // an event within the generated span, rather than including them as
-        // context on *every* request.
-        tracing::debug!(parent: &span, headers = ?info.headers(), "received request");
+        tracing::debug!(parent: &span, "received request");
 
         span
     })
@@ -205,7 +202,7 @@ impl<'a> Info<'a> {
     }
 
     /// View the request headers.
-    pub fn headers(&self) -> &http::HeaderMap {
+    pub fn request_headers(&self) -> &http::HeaderMap {
         self.route.headers()
     }
 }


### PR DESCRIPTION
The headers can frequently contain sensitive info, so for now we shouldn't emit traces that might log this data accidentally.