### PR TITLE
Add .with_var filter

### DIFF
--- a/src/filter/inject.rs
+++ b/src/filter/inject.rs
@@ -1,0 +1,59 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::{ready, TryFuture};
+use pin_project::pin_project;
+
+use super::{Filter, FilterBase, Func, Internal};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Inject<T, V> {
+    pub(super) filter: T,
+    pub(super) variable: V,
+}
+
+impl<T, V> FilterBase for Inject<T, V>
+where
+    T: Filter,
+    V: Clone + Send,
+{
+    type Extract = (V, T::Extract,);
+    type Error = T::Error;
+    type Future = InjectFuture<T, V>;
+    #[inline]
+    fn filter(&self, _: Internal) -> Self::Future {
+        InjectFuture {
+            extract: self.filter.filter(Internal),
+            variable: self.variable.clone(),
+        }
+    }
+}
+
+#[allow(missing_debug_implementations)]
+#[pin_project]
+pub struct InjectFuture<T: Filter, V> {
+    #[pin]
+    extract: T::Future,
+    variable: V,
+}
+
+impl<T, V> Future for InjectFuture<T, V>
+where
+    T: Filter,
+    V: Clone + Send,
+{
+    type Output = Result<(V, T::Extract,), T::Error>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let pin = self.project();
+        match ready!(pin.extract.try_poll(cx)) {
+            Ok(ex) => {
+                let ex = (pin.variable.clone(), ex,);
+                Poll::Ready(Ok(ex))
+            }
+            Err(err) => Poll::Ready(Err(err)),
+        }
+    }
+}

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod service;
 mod unify;
 mod untuple_one;
 mod wrap;
+mod inject;
 
 use std::future::Future;
 use std::pin::Pin;

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -22,6 +22,7 @@ pub mod query;
 pub mod reply;
 pub mod sse;
 pub mod trace;
+pub mod var;
 #[cfg(feature = "websocket")]
 pub mod ws;
 

--- a/src/filters/var.rs
+++ b/src/filters/var.rs
@@ -1,0 +1,13 @@
+//! Variable Filter
+
+use crate::filter::Filter;
+use std::convert::Infallible;
+
+/// Creates a `Filter` that clones in its given variable into each request
+pub fn with_var<T>(var: T) -> impl Filter<Extract = (T,), Error = Infallible> + Clone
+where
+    T: Clone + Send,
+{
+    // The clone is needed since the produced closure will be run multiple times
+    super::any::any().map(move || var.clone())
+}


### PR DESCRIPTION
Adds a generic filter for binding in any Send + Clone variable into any filter chain. Useful for binding in database connections, password hashing settings etc. into handlers.

Not necessarily relevant to have in the framework, but nice to have in case you want it.

(If it is of interest I can write up an example with it as well)