### PR TITLE
Remove `Sync` restriction on stream bassed into `warp::sse::reply`

### DIFF
--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -385,7 +385,7 @@ where
 /// ```
 pub fn reply<S>(event_stream: S) -> impl Reply
 where
-    S: TryStream + Send + Sync + 'static,
+    S: TryStream + Send + 'static,
     S::Ok: ServerSentEvent,
     S::Error: StdError + Send + Sync + 'static,
 {
@@ -399,7 +399,7 @@ struct SseReply<S> {
 
 impl<S> Reply for SseReply<S>
 where
-    S: TryStream + Send + Sync + 'static,
+    S: TryStream + Send + 'static,
     S::Ok: ServerSentEvent,
     S::Error: StdError + Send + Sync + 'static,
 {


### PR DESCRIPTION
As the `Sync` requirement on `Body::wrap_stream` was removed in https://github.com/hyperium/hyper/pull/2187, it can now also be removed on the stream passed to `warp::sse::reply`.