### PR TITLE
Document that filters::query::query uses serde_urlencoded, and add example for postprocessing filters::query::raw

### DIFF
--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -59,6 +59,10 @@ use crate::reject::{self, Rejection};
 ///     });
 /// ```
 ///
+/// Not all structs are supported for use as query objects, e.g. structs containing vectors will
+/// result in an error at runtime. If you need more flexibility, consider using [raw] to supply
+/// your own deserialization mechanism.
+///
 /// For more examples, please take a look at [examples/query_string.rs](https://github.com/seanmonstar/warp/blob/master/examples/query_string.rs).
 ///
 /// [Serde]: https://docs.rs/serde


### PR DESCRIPTION
`serde_urlencoded` is used for to deserialize query strings, and hence not all structs that are `Deserialize` can be deserialized to. I think it would be neat to document that fact and also added an example that shows how to use a different deserialization function instead.

(I didn't want to add serde_qs as a dev-dependency just for this, so I fudged it.)

What do you think?