### PR TITLE
Upgrade dependence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ tracing = { version = "0.1", default-features = false, features = ["log", "std"]
 tracing-futures = { version = "0.2", default-features = false, features = ["std-future"] }
 tower-service = "0.3"
 # tls is enabled by default, we don't want that yet
-tokio-tungstenite = { version = "0.10", default-features = false, optional = true }
+tokio-tungstenite = { version = "0.11", default-features = false, optional = true }
 urlencoding = "1.0.0"
 pin-project = "0.4.17"
-tokio-rustls = { version = "0.13.1", optional = true }
+tokio-rustls = { version = "0.14", optional = true }
 
 [dev-dependencies]
 pretty_env_logger = "0.4"


### PR DESCRIPTION
Fix #694 

It works well in my environment.

But when other user mixes use tokio-tungstenite v0.10 and v0.11, there will be compatibility issues.

ps: upgrade to the same version can solve this problem