### PR TITLE
Fix #568

### DIFF
--- a/src/route.rs
+++ b/src/route.rs
@@ -95,14 +95,13 @@ impl Route {
 
     pub(crate) fn set_unmatched_path(&mut self, index: usize) {
         let index = self.segments_index + index;
-
         let path = self.req.uri().path();
-
-        if path.len() == index {
+        if path.len() < index {
+            return;
+        } else if path.len() == index {
             self.segments_index = index;
         } else {
             debug_assert_eq!(path.as_bytes()[index], b'/');
-
             self.segments_index = index + 1;
         }
     }

--- a/src/route.rs
+++ b/src/route.rs
@@ -97,8 +97,7 @@ impl Route {
         let index = self.segments_index + index;
         let path = self.req.uri().path();
         if path.is_empty() {
-            // note: empty path is malformed due to
-            // mismatch in output of path_and_query
+            // malformed path
             return;
         } else if path.len() == index {
             self.segments_index = index;

--- a/src/route.rs
+++ b/src/route.rs
@@ -96,7 +96,9 @@ impl Route {
     pub(crate) fn set_unmatched_path(&mut self, index: usize) {
         let index = self.segments_index + index;
         let path = self.req.uri().path();
-        if path.len() == 0 {
+        if path.is_empty() {
+            // note: empty path is malformed due to
+            // mismatch in output of path_and_query
             return;
         } else if path.len() == index {
             self.segments_index = index;

--- a/src/route.rs
+++ b/src/route.rs
@@ -96,7 +96,7 @@ impl Route {
     pub(crate) fn set_unmatched_path(&mut self, index: usize) {
         let index = self.segments_index + index;
         let path = self.req.uri().path();
-        if path.len() < index {
+        if path.len() == 0 {
             return;
         } else if path.len() == index {
             self.segments_index = index;

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -43,6 +43,13 @@ async fn dir() {
     assert_eq!(res.headers()["accept-ranges"], "bytes");
 
     assert_eq!(res.body(), &*contents);
+
+    let malformed_req = warp::test::request().path("todos.rs");
+    assert!(malformed_req
+        .filter(&file)
+        .await
+        .unwrap_err()
+        .is_not_found());
 }
 
 #[tokio::test]

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -45,11 +45,7 @@ async fn dir() {
     assert_eq!(res.body(), &*contents);
 
     let malformed_req = warp::test::request().path("todos.rs");
-    assert!(malformed_req
-        .filter(&file)
-        .await
-        .unwrap_err()
-        .is_not_found());
+    assert_eq!(malformed_req.reply(&file).await.status(), 404);
 }
 
 #[tokio::test]

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -151,6 +151,13 @@ async fn tail() {
 
     let m = tail.and(warp::path::end());
     assert!(warp::test::request().path("/foo/bar").matches(&m).await);
+
+    let ex = warp::test::request()
+        .path("localhost")
+        .filter(&tail)
+        .await
+        .unwrap();
+    assert_eq!(ex.as_str(), "/");
 }
 
 #[tokio::test]


### PR DESCRIPTION
This is difficult to reproduce, the provided code snippet in the issue did not run (mismatched parens etc)

The full code snippet that I believe the issue author was trying to provide would look more like:

```
use warp::Filter;

#[tokio::main]
async fn main() {
    let static_server = warp::get()
        .and(warp::fs::dir("files"))
        .with(warp::log::log("static webserver"));
    warp::serve(static_server).run(([0, 0, 0, 0], 3030)).await;
}
```

However, it's unclear how to send a malformed request like the one they were referencing, precisely _because_ it is malformed.

Instead I added a breaking test that I think mimics that malformed request, and then added code to fix it.