### PR TITLE
Backport of tail crash fix #568 (#697) to 0.1.x

### DIFF
--- a/examples/handlebars_template.rs
+++ b/examples/handlebars_template.rs
@@ -6,7 +6,6 @@ extern crate warp;
 extern crate serde_json;
 extern crate serde;
 
-use std::error::Error;
 use std::sync::Arc;
 
 use handlebars::Handlebars;
@@ -23,7 +22,7 @@ where
     T: Serialize,
 {
     hbs.render(template.name, &template.value)
-        .unwrap_or_else(|err| err.description().to_owned())
+        .unwrap_or_else(|err| err.to_string().to_owned())
 }
 
 fn main() {

--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -460,8 +460,9 @@ fn path_and_query(route: &Route) -> PathAndQuery {
     route
         .uri()
         .path_and_query()
-        .expect("server URIs should always have path_and_query")
-        .clone()
+        .cloned()
+        .unwrap_or_else(|| PathAndQuery::from_static(""))
+
 }
 
 /// Convenient way to chain multiple path filters together.

--- a/src/route.rs
+++ b/src/route.rs
@@ -92,14 +92,14 @@ impl Route {
 
     pub(crate) fn set_unmatched_path(&mut self, index: usize) {
         let index = self.segments_index + index;
-
         let path = self.req.uri().path();
-
-        if path.len() == index {
+        if path.is_empty() {
+            // malformed path
+            return;
+        } else if path.len() == index {
             self.segments_index = index;
         } else {
             debug_assert_eq!(path.as_bytes()[index], b'/');
-
             self.segments_index = index + 1;
         }
     }

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -46,6 +46,9 @@ fn dir() {
     assert_eq!(res.headers()["accept-ranges"], "bytes");
 
     assert_eq!(res.body(), &*contents);
+
+    let malformed_req = warp::test::request().path("todos.rs");
+    assert_eq!(malformed_req.reply(&file).status(), 404);
 }
 
 #[test]

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -155,6 +155,12 @@ fn tail() {
     assert!(warp::test::request()
         .path("/foo/bar")
         .matches(&tail.and(warp::path::end())));
+
+    let ex = warp::test::request()
+        .path("localhost")
+        .filter(&tail)
+        .unwrap();
+    assert_eq!(ex.as_str(), "/");
 }
 
 #[test]


### PR DESCRIPTION
return from set_unmatched_path on malformed path, closes #568 and #460, backport to 0.1.x
