### PR TITLE
Permit stapling an OCSP response when using TLS

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -435,6 +435,11 @@ where
         self.with_tls(|tls| tls.cert(cert.as_ref()))
     }
 
+    /// Specify the DER-encoded OCSP response.
+    pub fn ocsp_resp(self, resp: impl AsRef<[u8]>) -> Self {
+        self.with_tls(|tls| tls.ocsp_resp(resp.as_ref()))
+    }
+
     fn with_tls<Func>(self, func: Func) -> Self
     where
         Func: FnOnce(TlsConfigBuilder) -> TlsConfigBuilder,


### PR DESCRIPTION
OCSP isn't widely supported yet in rust TLS land (e.g. creating requests/responses) but rustls provides the stapling mechanism—you can supply a chunk of bytes, which is presumed to be a valid DER response, which is passed verbatim to the client.

In an ideal world this would become more fully featured:
* automatic fetching and caching of the OCSP response
* updating the response without having to restart the server, since any token is usually only valid for 7 days.

However the barebones/static version of this is useful to me and I would like to simply expose the rustls config.