### PR TITLE
Incoming support `Transport::remote_addr`

### DIFF
--- a/examples/remote_addr.rs
+++ b/examples/remote_addr.rs
@@ -1,0 +1,99 @@
+#![deny(warnings)]
+
+use std::io::Error;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use warp::Transport;
+use warp::Filter;
+
+use futures::Stream;
+use tokio::io::AsyncRead;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::prelude::AsyncWrite;
+
+pub struct MyS {
+    stream: TcpStream,
+}
+
+impl Transport for MyS {
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        match self.stream.peer_addr() {
+            Ok(o) => Some(o),
+            Err(_) => None,
+        }
+    }
+}
+
+impl AsyncRead for MyS {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        let ptr = self.get_mut();
+        Pin::new(&mut ptr.stream).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for MyS {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, Error>> {
+        let ptr = self.get_mut();
+        Pin::new(&mut ptr.stream).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        let ptr = self.get_mut();
+        Pin::new(&mut ptr.stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        let ptr = self.get_mut();
+        Pin::new(&mut ptr.stream).poll_shutdown(cx)
+    }
+}
+
+pub struct MyIncoming {
+    listen: TcpListener,
+}
+
+impl Stream for MyIncoming {
+    type Item = Result<MyS, std::io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let ptr = self.get_mut();
+        match Pin::new(&mut ptr.listen).poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(o) => match o {
+                Some(item) => match item {
+                    Ok(o) => Poll::Ready(Some(Ok(MyS { stream: o }))),
+                    Err(e) => Poll::Ready(Some(Err(e))),
+                },
+                None => Poll::Ready(None),
+            },
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // Match any request and return hello world!
+    let routes = warp::addr::remote().map(|remote: Option<SocketAddr>| {
+        format!("{:?}", remote)
+    });
+
+    let srv = warp::serve(routes);
+
+    let s = "127.0.0.1:3000";
+    let addr = s.parse::<SocketAddr>().unwrap();
+    let listen = TcpListener::bind(&addr).await.unwrap();
+
+    let my = MyIncoming { listen };
+
+    srv.run_incoming_v2(my).await;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,10 +99,12 @@ mod service;
 pub mod test;
 #[cfg(feature = "tls")]
 mod tls;
+/// impl `Transport` to ensure `ws::addr::remote` return value
 mod transport;
 
 pub use self::error::Error;
 pub use self::filter::Filter;
+pub use self::transport::Transport;
 // This otherwise shows a big dump of re-exports in the doc homepage,
 // with zero context, so just hide it from the docs. Doc examples
 // on each can show that a convenient import exists.

--- a/src/server.rs
+++ b/src/server.rs
@@ -151,6 +151,21 @@ where
             .await;
     }
 
+    /// Run this `Server` forever on the current thread with a specific stream
+    /// of incoming connections.
+    ///
+    /// This can be ONLY used for TcpStream (which you can get peer_addr)
+    pub async fn run_incoming_v2<I>(self, incoming: I)
+    where
+        I: TryStream + Send,
+        I::Ok: AsyncRead + AsyncWrite + Send + 'static + Unpin + Transport,
+        I::Error: Into<Box<dyn StdError + Send + Sync>>,
+    {
+        self.run_incoming2(incoming.map_ok(crate::transport::LiftIoV2).into_stream())
+            .instrument(tracing::info_span!("Server::run_incoming"))
+            .await;
+    }
+
     async fn run_incoming2<I>(self, incoming: I)
     where
         I: TryStream + Send,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -6,7 +6,10 @@ use std::task::{Context, Poll};
 use hyper::server::conn::AddrStream;
 use tokio::io::{AsyncRead, AsyncWrite};
 
+/// impl Transport for your custom `Incoming`
+/// to ensure `ws::addr::remote` return meaningful value
 pub trait Transport: AsyncRead + AsyncWrite {
+    /// get underline stream's remote addr
     fn remote_addr(&self) -> Option<SocketAddr>;
 }
 
@@ -49,5 +52,41 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for LiftIo<T> {
 impl<T: AsyncRead + AsyncWrite + Unpin> Transport for LiftIo<T> {
     fn remote_addr(&self) -> Option<SocketAddr> {
         None
+    }
+}
+
+pub(crate) struct LiftIoV2<T>(pub(crate) T);
+
+impl<T: AsyncRead + Unpin> AsyncRead for LiftIoV2<T> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().0).poll_read(cx, buf)
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for LiftIoV2<T> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.get_mut().0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.get_mut().0).poll_shutdown(cx)
+    }
+}
+
+impl<T: AsyncRead + AsyncWrite + Unpin + Transport> Transport for LiftIoV2<T> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        self.0.remote_addr()
     }
 }


### PR DESCRIPTION
The current `run_incoming` does not support obtaining `remote_addr` dute to impl (PS: always return None).

```rust
impl<T: AsyncRead + AsyncWrite + Unpin> Transport for LiftIo<T> {
    fn remote_addr(&self) -> Option<SocketAddr> {
        None
    }
}
``` 

After some investigated, I think the most elegant solution should be to use specialization, so that user can `specialize` his own type override the default impl.

```rust
/// re-impl if specialization is available
impl<T: AsyncRead + AsyncWrite + Unpin> Transport for LiftIo<T> {
    default fn remote_addr(&self) -> Option<SocketAddr> {
        None
    }
}
``` 

Unfortunatly,  [specialization](https://github.com/rust-lang/rust/issues/31844) is not available in stable channel and will not be available in foreseeable future.

So I write a dirty copy-and-paste impl.