### PR TITLE
Add a http-kv example

### DIFF
--- a/examples/dyn_reply.rs
+++ b/examples/dyn_reply.rs
@@ -1,11 +1,20 @@
 #![deny(warnings)]
+
+use serde_derive::{Deserialize, Serialize};
 use warp::{http::StatusCode, Filter};
 
+#[derive(Deserialize, Serialize, Clone)]
+struct Value {
+    value: String,
+}
+
 async fn dyn_reply(word: String) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
-    if &word == "hello" {
-        Ok(Box::new("world"))
-    } else {
-        Ok(Box::new(StatusCode::BAD_REQUEST))
+    match word.as_str() {
+        "hello" => Ok(Box::new("world")), // how to reply "world" with different status code
+        "world" => Ok(Box::new(warp::reply::json(&Value {
+            value: "Good".to_string(),
+        }))), // how to reply json with different status code
+        _ => Ok(Box::new(StatusCode::BAD_REQUEST)),
     }
 }
 

--- a/examples/dyn_reply.rs
+++ b/examples/dyn_reply.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 use serde_derive::{Deserialize, Serialize};
-use warp::{http::StatusCode, Filter};
+use warp::{http::Response, http::StatusCode, Filter};
 
 #[derive(Deserialize, Serialize, Clone)]
 struct Value {
@@ -10,10 +10,16 @@ struct Value {
 
 async fn dyn_reply(word: String) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
     match word.as_str() {
-        "hello" => Ok(Box::new("world")), // how to reply "world" with different status code
+        "hello" => Ok(Box::new("world")),
         "world" => Ok(Box::new(warp::reply::json(&Value {
             value: "Good".to_string(),
         }))), // how to reply json with different status code
+        "create" => Ok(Box::new(
+            Response::builder()
+                .status(201)
+                .body("world created")
+                .unwrap(),
+        )),
         _ => Ok(Box::new(StatusCode::BAD_REQUEST)),
     }
 }

--- a/examples/http_kv.rs
+++ b/examples/http_kv.rs
@@ -1,0 +1,79 @@
+use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::env;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use warp::reply::Json;
+use warp::{reject, Filter, Rejection};
+
+#[derive(Deserialize, Serialize, Clone)]
+struct Value {
+    value: String,
+}
+
+/// Provides a RESTful web server as a simple key value store
+///
+/// API will be:
+///
+/// - `GET /:key`: get the value with key
+/// - `POST /:key "{"value": "some stuff"}"`: create/update a new key with value
+/// - `DELETE /:key`: delete a specific key
+///
+/// Testing curl command could be:
+/// - `curl -i -X POST -H "Content-Type:application/json" localhost:3030/k1 -d '{"value": "v1"}'`
+/// - `curl -i -X GET -H "Content-Type:application/json" localhost:3030/k1`
+/// - `curl -i -X DELETE -H "Content-Type:application/json" localhost:3030/k1`
+#[tokio::main]
+async fn main() {
+    if env::var_os("RUST_LOG").is_none() {
+        // Set `RUST_LOG=todos=debug` to see debug logs,
+        // this only shows access logs.
+        env::set_var("RUST_LOG", "http_kv=info");
+    }
+    pretty_env_logger::init();
+
+    // Use simple map as an in memory KV store
+    type Map = Arc<Mutex<HashMap<String, Value>>>;
+    let map: Map = Arc::new(Mutex::new(HashMap::new()));
+
+    let map_clone = map.clone();
+    let post = warp::post()
+        .and(warp::path::param::<String>())
+        .and(warp::body::content_length_limit(1024 * 16).and(warp::body::json()))
+        .and(warp::any().map(move || map_clone.clone()))
+        .and_then(|key, value: Value, map: Map| async move {
+            // use `move` keyword to let the closure owns key and value
+            match map.lock().await.insert(key, value.clone()) {
+                Some(_) => Ok(warp::reply::json(&value)) as Result<Json, Rejection>, // Otherwise error: cannot infer type for type parameter `E` declared on the enum `Result`
+                None => Ok(warp::reply::json(&value)), // TODO: return 201 here, and 200 above
+            }
+        });
+
+    let map_clone = map.clone();
+    let get = warp::get()
+        .and(warp::path::param::<String>())
+        .and(warp::any().map(move || map_clone.clone()))
+        .and_then(|key: String, map: Map| async move {
+            match map.lock().await.get(key.as_str()) {
+                Some(value) => Ok(warp::reply::json(value)),
+                None => Err(reject::not_found()), // TODO: why not getting not found but a `HTTP method not allowed`?
+            }
+        });
+
+    let map_clone = map.clone();
+    let delete = warp::delete()
+        .and(warp::path::param::<String>())
+        .and(warp::any().map(move || map_clone.clone()))
+        .and_then(|key: String, map: Map| async move {
+            match map.lock().await.remove(key.as_str()) {
+                Some(value) => Ok(warp::reply::json(&value)),
+                None => Err(reject::not_found()), // TODO: why not getting not found but a `HTTP method not allowed`?
+            }
+        });
+
+    // View access logs by setting `RUST_LOG=todos`.
+    let routes = get.or(post).or(delete).with(warp::log("http_kv"));
+    // Start up the server...
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+}

--- a/examples/http_kv.rs
+++ b/examples/http_kv.rs
@@ -4,8 +4,10 @@ use std::env;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use warp::reply::Json;
-use warp::{reject, Filter, Rejection};
+use warp::{http::StatusCode, Filter, Rejection, Reply};
+
+// Use simple map as an in memory KV store
+type Map = Arc<Mutex<HashMap<String, Value>>>;
 
 #[derive(Deserialize, Serialize, Clone)]
 struct Value {
@@ -32,9 +34,6 @@ async fn main() {
         env::set_var("RUST_LOG", "http_kv=info");
     }
     pretty_env_logger::init();
-
-    // Use simple map as an in memory KV store
-    type Map = Arc<Mutex<HashMap<String, Value>>>;
     let map: Map = Arc::new(Mutex::new(HashMap::new()));
 
     let map_clone = map.clone();
@@ -42,38 +41,43 @@ async fn main() {
         .and(warp::path::param::<String>())
         .and(warp::body::content_length_limit(1024 * 16).and(warp::body::json()))
         .and(warp::any().map(move || map_clone.clone()))
-        .and_then(|key, value: Value, map: Map| async move {
-            // use `move` keyword to let the closure owns key and value
-            match map.lock().await.insert(key, value.clone()) {
-                Some(_) => Ok(warp::reply::json(&value)) as Result<Json, Rejection>, // Otherwise error: cannot infer type for type parameter `E` declared on the enum `Result`
-                None => Ok(warp::reply::json(&value)), // TODO: return 201 here, and 200 above
-            }
-        });
+        .and_then(|key: String, value: Value, map: Map| post_handler(key, value, map));
 
     let map_clone = map.clone();
     let get = warp::get()
         .and(warp::path::param::<String>())
         .and(warp::any().map(move || map_clone.clone()))
-        .and_then(|key: String, map: Map| async move {
-            match map.lock().await.get(key.as_str()) {
-                Some(value) => Ok(warp::reply::json(value)),
-                None => Err(reject::not_found()), // TODO: why not getting not found but a `HTTP method not allowed`?
-            }
-        });
+        .and_then(|key: String, map: Map| get_handler(key, map));
 
     let map_clone = map.clone();
     let delete = warp::delete()
         .and(warp::path::param::<String>())
         .and(warp::any().map(move || map_clone.clone()))
-        .and_then(|key: String, map: Map| async move {
-            match map.lock().await.remove(key.as_str()) {
-                Some(value) => Ok(warp::reply::json(&value)),
-                None => Err(reject::not_found()), // TODO: why not getting not found but a `HTTP method not allowed`?
-            }
-        });
+        .and_then(|key: String, map: Map| delete_handler(key, map));
 
     // View access logs by setting `RUST_LOG=todos`.
     let routes = get.or(post).or(delete).with(warp::log("http_kv"));
     // Start up the server...
     warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+}
+
+async fn post_handler(key: String, value: Value, map: Map) -> Result<Box<dyn Reply>, Rejection> {
+    match map.lock().await.insert(key, value.clone()) {
+        Some(_) => Ok(Box::new(warp::reply::json(&value))),
+        None => Ok(Box::new(warp::reply::json(&value))), // TODO: return 201 here, and 200 above
+    }
+}
+
+async fn get_handler(key: String, map: Map) -> Result<Box<dyn Reply>, Rejection> {
+    match map.lock().await.get(key.as_str()) {
+        Some(value) => Ok(Box::new(warp::reply::json(value).into_response())),
+        None => Ok(Box::new(StatusCode::NOT_FOUND)),
+    }
+}
+
+async fn delete_handler(key: String, map: Map) -> Result<Box<dyn Reply>, Rejection> {
+    match map.lock().await.remove(key.as_str()) {
+        Some(value) => Ok(Box::new(warp::reply::json(&value).into_response())),
+        None => Ok(Box::new(StatusCode::NOT_FOUND)),
+    }
 }

--- a/examples/http_kv.rs
+++ b/examples/http_kv.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use warp::{http::StatusCode, Filter, Rejection, Reply};
+use warp::{http::Response, http::StatusCode, Filter, Rejection, Reply};
 
 // Use simple map as an in memory KV store
 type Map = Arc<Mutex<HashMap<String, Value>>>;
@@ -78,6 +78,11 @@ async fn get_handler(key: String, map: Map) -> Result<Box<dyn Reply>, Rejection>
 async fn delete_handler(key: String, map: Map) -> Result<Box<dyn Reply>, Rejection> {
     match map.lock().await.remove(key.as_str()) {
         Some(value) => Ok(Box::new(warp::reply::json(&value).into_response())),
-        None => Ok(Box::new(StatusCode::NOT_FOUND)),
+        None => Ok(Box::new(
+            Response::builder()
+                .status(404)
+                .body("nothing deleted")
+                .unwrap(),
+        )),
     }
 }


### PR DESCRIPTION
As I had some fun trying to use warp to create a simple http server as a simple key/value storage, I think it might be nice to have this as an example?

It can illustrate how to use `async move {}` closures. And I feel it is a bit simpler than the Todo example.

A few questions though:

1. It seems that on line 44 I cannot use `.and(warp::any().map(|| map_clone))`, and clone it twice seems a bit weird but that's how I get it compiled otherwise I have error saying I am providing a FnOnce not Fn or something.
2. I haven't figure out a way to conveniently return a Json with a different HTTP code than 200.
3. I tried to use `Err(reject::not_found())` for the key not found path but while curling I saw `405 Method Not Allowed` instead of a `404`, not really sure why 🤔 

Hopefully you think this could be a valuable example? And it would be nice if you could help answer some of the questions above so I can remove some of the TODOs in the code. 

Thank you.