### PR TITLE
WIP A Result can be a Reply

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -411,19 +411,24 @@ impl Reply for ::http::StatusCode {
     }
 }
 
-impl<T> Reply for Result<T, ::http::Error>
+impl<T, E> Reply for Result<T, E>
 where
     T: Reply + Send,
+    E: Reply + Send + std::error::Error,
 {
     #[inline]
     fn into_response(self) -> Response {
         match self {
             Ok(t) => t.into_response(),
-            Err(e) => {
-                tracing::error!("reply error: {:?}", e);
-                StatusCode::INTERNAL_SERVER_ERROR.into_response()
-            }
+            Err(e) => e.into_response(),
         }
+    }
+}
+impl Reply for ::http::Error {
+    #[inline]
+    fn into_response(self) -> Response {
+        tracing::error!("reply error: {:?}", self);
+        StatusCode::INTERNAL_SERVER_ERROR.into_response()
     }
 }
 


### PR DESCRIPTION
Provide `impl Reply for Result<T, E>` where both `T` and `E` implements Reply.  This impl makes no difference between an Ok and an Err, but calls `into_response` for the contained data of either.  If  an error should be logged, that is the responsibility of the `Reply` impl on the `E` type.

This is testing my suggestion https://github.com/seanmonstar/warp/issues/712#issuecomment-722389194 .

To be really useful, it needs a way to use `async fn foo(...) -> impl Reply` as an handler.  Filter `.map` does not do async while `.and_then` needs a `Resule<impl Reply, Rejecttion>`.  Is there a middle version?