### PR TITLE
Bump `tokio` from `0.2` to `0.3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tracing = { version = "0.1", default-features = false, features = ["log", "std"]
 tracing-futures = { version = "0.2", default-features = false, features = ["std-future"] }
 tower-service = "0.3"
 # tls is enabled by default, we don't want that yet
-tokio-tungstenite = { git = "https://github.com/snapview/tokio-tungstenite", default-features = false, optional = true }
+tokio-tungstenite = { version = "0.12", default-features = false, optional = true }
 percent-encoding = "2.1"
 pin-project = "1.0"
 tokio-rustls = { version = "0.20", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bytes = "0.5"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 headers = "0.3"
 http = "0.2"
-hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio", features = ["stream"] }
+hyper = { git = "https://github.com/hyperium/hyper", features = ["stream"] }
 log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "warp"
+name = "warp" 
 version = "0.2.5" # don't forget to update html_root_url
-description = "serve the web at warp speeds"
-authors = ["Sean McArthur <sean@seanmonstar.com>"]
-license = "MIT"
-readme = "README.md"
-documentation = "https://docs.rs/warp"
-repository = "https://github.com/seanmonstar/warp"
-categories = ["web-programming::http-server"]
-keywords = ["warp", "server", "http", "hyper"]
-autotests = true
-autoexamples = true
-edition = "2018"
+description = "serve the web at warp speeds" 
+authors = ["Sean McArthur <sean@seanmonstar.com>"] 
+license = "MIT" 
+readme = "README.md" 
+documentation = "https://docs.rs/warp" 
+repository = "https://github.com/seanmonstar/warp" 
+categories = ["web-programming::http-server"] 
+keywords = ["warp", "server", "http", "hyper"] 
+autotests = true 
+autoexamples = true 
+edition = "2018" 
 
 [package.metadata.docs.rs]
 all-features = true
@@ -22,7 +22,7 @@ bytes = "0.5"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 headers = "0.3"
 http = "0.2"
-hyper = { version = "0.13", features = ["stream"] }
+hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio", features = ["stream"] }
 log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.0"
@@ -31,15 +31,15 @@ scoped-tls = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7"
-tokio = { version = "0.2", features = ["fs", "stream", "sync", "time"] }
+tokio = { version = "0.3", features = ["fs", "stream", "sync", "time"] }
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 tracing-futures = { version = "0.2", default-features = false, features = ["std-future"] }
 tower-service = "0.3"
 # tls is enabled by default, we don't want that yet
-tokio-tungstenite = { version = "0.11", default-features = false, optional = true }
+tokio-tungstenite = { git = "https://github.com/snapview/tokio-tungstenite", default-features = false, optional = true }
 percent-encoding = "2.1"
 pin-project = "1.0"
-tokio-rustls = { version = "0.14", optional = true }
+tokio-rustls = { version = "0.20", optional = true }
 
 [dev-dependencies]
 pretty_env_logger = "0.4"
@@ -47,7 +47,7 @@ tracing-subscriber = "0.2.7"
 tracing-log = "0.1"
 serde_derive = "1.0"
 handlebars = "3.0.0"
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "0.3", features = ["macros"] }
 listenfd = "0.3"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tokio-tungstenite = { version = "0.12", default-features = false, optional = tru
 percent-encoding = "2.1"
 pin-project = "1.0"
 tokio-rustls = { version = "0.20", optional = true }
+tokio-util = { git = "https://github.com/tokio-rs/tokio/", features = ["io"] }
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tracing-subscriber = "0.2.7"
 tracing-log = "0.1"
 serde_derive = "1.0"
 handlebars = "3.0.0"
-tokio = { version = "0.3", features = ["macros"] }
+tokio = { version = "0.3", features = ["macros", "rt-multi-thread"] }
 listenfd = "0.3"
 
 [features]
@@ -78,7 +78,7 @@ required-features = ["compression"]
 
 [[example]]
 name = "unix_socket"
-required-features = ["tokio/uds"]
+required-features = ["tokio/net"]
 
 [[example]]
 name = "websockets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "warp" 
+name = "warp"
 version = "0.2.5" # don't forget to update html_root_url
-description = "serve the web at warp speeds" 
-authors = ["Sean McArthur <sean@seanmonstar.com>"] 
-license = "MIT" 
-readme = "README.md" 
-documentation = "https://docs.rs/warp" 
-repository = "https://github.com/seanmonstar/warp" 
-categories = ["web-programming::http-server"] 
-keywords = ["warp", "server", "http", "hyper"] 
-autotests = true 
-autoexamples = true 
-edition = "2018" 
+description = "serve the web at warp speeds"
+authors = ["Sean McArthur <sean@seanmonstar.com>"]
+license = "MIT"
+readme = "README.md"
+documentation = "https://docs.rs/warp"
+repository = "https://github.com/seanmonstar/warp"
+categories = ["web-programming::http-server"]
+keywords = ["warp", "server", "http", "hyper"]
+autotests = true
+autoexamples = true
+edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/futures.rs
+++ b/examples/futures.rs
@@ -16,7 +16,7 @@ async fn main() {
 }
 
 async fn sleepy(Seconds(seconds): Seconds) -> Result<impl warp::Reply, Infallible> {
-    tokio::time::delay_for(Duration::from_secs(seconds)).await;
+    tokio::time::sleep(Duration::from_secs(seconds)).await;
     Ok(format!("I waited {} seconds!", seconds))
 }
 

--- a/examples/unix_socket.rs
+++ b/examples/unix_socket.rs
@@ -6,8 +6,7 @@ use tokio::net::UnixListener;
 async fn main() {
     pretty_env_logger::init();
 
-    let mut listener = UnixListener::bind("/tmp/warp.sock").unwrap();
-    let incoming = listener.incoming();
+    let incoming = UnixListener::bind("/tmp/warp.sock").unwrap();
     warp::serve(warp::fs::dir("examples/dir"))
         .run_incoming(incoming)
         .await;

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -22,7 +22,7 @@ use hyper::Body;
 use mime_guess;
 use percent_encoding::percent_decode_str;
 use tokio::fs::File as TkFile;
-use tokio::io::{AsyncRead, AsyncSeek, ReadBuf};
+use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
 
 use crate::filter::{Filter, FilterClone, One};
 use crate::reject::{self, Rejection};
@@ -399,7 +399,7 @@ fn file_stream(
 
     let seek = async move {
         if start != 0 {
-            AsyncSeek::start_seek(Pin::new(&mut file), SeekFrom::Start(start))?;
+            file.seek(SeekFrom::Start(start)).await?;
         }
         Ok(file)
     };

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -54,7 +54,7 @@ use hyper::Body;
 use pin_project::pin_project;
 use serde::Serialize;
 use serde_json;
-use tokio::time::{self, Delay};
+use tokio::time::{self, Sleep};
 
 use self::sealed::{
     BoxedServerSentEvent, EitherServerSentEvent, SseError, SseField, SseFormat, SseWrapper,
@@ -467,7 +467,7 @@ impl KeepAlive {
         S::Ok: ServerSentEvent + Send,
         S::Error: StdError + Send + Sync + 'static,
     {
-        let alive_timer = time::delay_for(self.max_interval);
+        let alive_timer = time::sleep(self.max_interval);
         SseKeepAlive {
             event_stream,
             comment_text: self.comment_text,
@@ -484,7 +484,7 @@ struct SseKeepAlive<S> {
     event_stream: S,
     comment_text: Cow<'static, str>,
     max_interval: Duration,
-    alive_timer: Delay,
+    alive_timer: Sleep,
 }
 
 #[doc(hidden)]
@@ -505,7 +505,7 @@ where
     let max_interval = keep_interval
         .into()
         .unwrap_or_else(|| Duration::from_secs(15));
-    let alive_timer = time::delay_for(max_interval);
+    let alive_timer = time::sleep(max_interval);
     SseKeepAlive {
         event_stream,
         comment_text: Cow::Borrowed(""),

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use futures::ready;
 use hyper::server::accept::Accept;
@@ -211,9 +211,9 @@ impl TlsStream {
 impl AsyncRead for TlsStream {
     fn poll_read(
         self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
         let pin = self.get_mut();
         match pin.state {
             State::Handshaking(ref mut accept) => match ready!(Pin::new(accept).poll(cx)) {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use hyper::server::conn::AddrStream;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 pub trait Transport: AsyncRead + AsyncWrite {
     fn remote_addr(&self) -> Option<SocketAddr>;
@@ -22,8 +22,8 @@ impl<T: AsyncRead + Unpin> AsyncRead for LiftIo<T> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
         Pin::new(&mut self.get_mut().0).poll_read(cx, buf)
     }
 }


### PR DESCRIPTION
Bump `tokio` and related dependencies (`hyper`, `tokio-rustls`, `tokio-tungstenite`).

**Checklist**
- [x] get branch of @hawkw merged into `hyper` (https://github.com/hyperium/hyper/pull/2317)
    - [ ] hyper release with changes
- [x] get `tokio-tungstenite` to make a release with `tokio 0.3`
- [ ] update `bytes` to `0.6` for `warp`
- [x] update `bytes` to `0.6` for `hyper` (https://github.com/hyperium/hyper/pull/2339)

Fixes #725