### PR TITLE
working auth filter rejection with authentication header and realm name

### DIFF
--- a/examples/basic_auth.rs
+++ b/examples/basic_auth.rs
@@ -1,0 +1,13 @@
+//#![deny(warnings)]
+use headers::{authorization::Basic, Authorization};
+use warp::Filter;
+
+#[tokio::main]
+async fn main() {
+    let routes = warp::auth::basic("Realm name").map(|auth_header: Authorization<Basic>| {
+        // TODO: some password lookups done in here
+        println!("authorization header = {:?}", auth_header);
+        format!("Hello, {} you're authenticated", auth_header.0.username())
+    });
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+}

--- a/src/filters/auth.rs
+++ b/src/filters/auth.rs
@@ -1,0 +1,30 @@
+//! HTTP Basic Authentication Filters
+
+use futures::future;
+use headers::{authorization::Basic, Authorization};
+
+use crate::filter::Filter;
+use crate::reject::Rejection;
+
+use super::header;
+
+/// Creates a `Filter` to the HTTP Basic Authentication header. If none was sent by the client, this filter will reject
+/// any request with a 401 Unauthorized.
+///
+/// # Example
+///
+/// ```
+/// use std::net::SocketAddr;
+/// use warp::Filter;
+/// use headers::{authorization::Basic, Authorization};
+///
+/// let route = warp::auth::basic("Realm name")
+///     .map(|auth_header: Authorization<Basic>| {
+///         println!("authorization header = {:?}", auth_header);
+///     });
+/// ```
+pub fn basic(
+    realm: &'static str,
+) -> impl Filter<Extract = (Authorization<Basic>,), Error = Rejection> + Copy {
+    header::header2().or_else(move |_| future::err(crate::reject::unauthorized(realm)))
+}

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod addr;
 pub mod any;
+pub mod auth;
 pub mod body;
 #[cfg(feature = "compression")]
 pub mod compression;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub use self::filters::{
     addr,
     // any() function
     any::any,
+    auth,
     body,
     cookie,
     // cookie() function


### PR DESCRIPTION
This is for issue #62 based on pr #716 but mine actually works. However I understand it is a crazy hack how I pass the realm name along to create the additional header. If some maintainer could guide me how to make that clean please? I'll fix it as needed.

For cleaner implementation: I'd assume we need a new rejection type. Because a failed authentication (i.e. user/pass wrong) will require the same headers returned as this authentication header missing filter does, only now needed by another filter: the one checking the credentials.