### PR TITLE
replaces "instead" with "intend" in allow_any_origin comments

### DIFF
--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -192,7 +192,7 @@ impl Builder {
     ///
     /// # Warning
     ///
-    /// This can allow websites you didn't instead to access this resource,
+    /// This can allow websites you didn't intend to access this resource,
     /// it is usually better to set an explicit list.
     pub fn allow_any_origin(mut self) -> Self {
         self.origins = None;


### PR DESCRIPTION
fixes https://github.com/seanmonstar/warp/issues/754