### PR TITLE
fix(sse): missing Sync bound

### DIFF
--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -385,7 +385,7 @@ where
 /// ```
 pub fn reply<S>(event_stream: S) -> impl Reply
 where
-    S: TryStream + Send + 'static,
+    S: TryStream + Send + Sync + 'static,
     S::Ok: ServerSentEvent,
     S::Error: StdError + Send + Sync + 'static,
 {
@@ -399,7 +399,7 @@ struct SseReply<S> {
 
 impl<S> Reply for SseReply<S>
 where
-    S: TryStream + Send + 'static,
+    S: TryStream + Send + Sync + 'static,
     S::Ok: ServerSentEvent,
     S::Error: StdError + Send + Sync + 'static,
 {


### PR DESCRIPTION
```
λ rustc --version
rustc 1.48.0 (7eac88abb 2020-11-16)

λ cargo check --example websockets
    Checking warp v0.2.5 (/Users/fundon/Workspaces/GitHub/Rust/web/warp)
error[E0277]: `S` cannot be shared between threads safely
   --> src/filters/sse.rs:418:55
    |
418 |         let mut res = Response::new(Body::wrap_stream(body_stream));
    |                                                       ^^^^^^^^^^^ `S` cannot be shared between threads safely
    |
   ::: /Users/fundon/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/hyper-0.13.3/src/body/body.rs:159:49
    |
159 |         S: Stream<Item = Result<O, E>> + Send + Sync + 'static,
    |                                                 ---- required by this bound in `Body::wrap_stream`
    |
    = note: required because it appears within the type `futures::stream::MapErr<S, [closure@src/filters/sse.rs:410:22: 414:14]>`
    = note: required because it appears within the type `futures::stream::IntoStream<futures::stream::MapErr<S, [closure@src/filters/sse.rs:410:22: 414:14]>>`
    = note: required because it appears within the type `futures::stream::AndThen<futures::stream::IntoStream<futures::stream::MapErr<S, [closure@src/filters/sse.rs:410:22: 414:14]>>, futures::future::Ready<std::result::Result<std::string::String, SseError>>, [closure@src/filters/sse.rs:416:23: 416:72]>`
help: consider further restricting this bound
    |
402 |     S: TryStream + Send + 'static + Sync,
    |                                   ^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `warp`

To learn more, run the command again with --verbose.
```