### PR TITLE
fix: use append instead of insert

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -386,7 +386,7 @@ impl<T: Reply> Reply for WithHeader<T> {
     fn into_response(self) -> Response {
         let mut res = self.reply.into_response();
         if let Some((name, value)) = self.header {
-            res.headers_mut().insert(name, value);
+            res.headers_mut().append(name, value);
         }
         res
     }


### PR DESCRIPTION
fixes #609
by using append, multiple cookies of the same name can be added.
this is required for some headers such as Set-Cookie in order to
set multiple cookies.