### PR TITLE
Update README for 0.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Since it builds on top of [hyper](https://hyper.rs), you automatically get:
 Add warp and Tokio to your dependencies:
 
 ```toml
-tokio = { version = "0.2", features = ["full"] }
-warp = "0.2"
+tokio = { version = "1", features = ["full"] }
+warp = "0.3"
 ```
 
 And then get started in your `main.rs`:


### PR DESCRIPTION
Update the README example to use Tokio 1.0 and Warp 0.3, as mentioned
[here](https://github.com/seanmonstar/warp/pull/777#issuecomment-761527432).