### PR TITLE
Fix: CORS: Allow spaces in Access-Control-Request-Headers values

### DIFF
--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -383,7 +383,7 @@ impl Configured {
                         .to_str()
                         .map_err(|_| Forbidden::HeaderNotAllowed)?;
                     for header in headers.split(',') {
-                        if !self.is_header_allowed(header) {
+                        if !self.is_header_allowed(header.trim()) {
                             return Err(Forbidden::HeaderNotAllowed);
                         }
                     }

--- a/tests/cors.rs
+++ b/tests/cors.rs
@@ -119,7 +119,7 @@ async fn success() {
     let res = warp::test::request()
         .method("OPTIONS")
         .header("origin", "https://hyper.rs")
-        .header("access-control-request-headers", "x-bar,x-foo")
+        .header("access-control-request-headers", "x-bar, x-foo")
         .header("access-control-request-method", "DELETE")
         .reply(&route)
         .await;


### PR DESCRIPTION
### Bug description

The current implementation does not correctly interpret the `Access-Control-Request-Headers` value in a CORS preflight if it includes spaces.

For example, if

 * warp cors is configured with `.allow_headers([header::AUTHORIZATION, header::CONTENT_LENGTH])` and
 * preflight request includes `Access-Control-Request-Headers: content-length, authorization`,
 
then the preflight request will be rejected (HTTP 403) because the header value is split on ",", and `" authorization"` (note the space!) is not in the list of allowed headers.

### Fix

This PR adds a `.trim()` to the parsing process to allow for spaces in `Access-Control-Request-Headers` header values. It tweaks a test so that it fails without this PR's fix.

### Note

Technically, the standard prescribes that `Access-Control-Request-Headers` values should _not_ contain spaces -- see https://fetch.spec.whatwg.org/#cors-preflight-fetch, step 5. However
  1) The internet is rife with examples that do contain spaces, including the [official MDN documentation for the header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers#examples)
  2) At least some existing http clients generate values with clients, e.g. [jsdom](https://www.npmjs.com/package/jsdom), a major Node library

So it seems like a good idea to be mildly lenient with parsing here.