### PR TITLE
Use append instead of insert when adding headers using WithHeader

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -386,7 +386,7 @@ impl<T: Reply> Reply for WithHeader<T> {
     fn into_response(self) -> Response {
         let mut res = self.reply.into_response();
         if let Some((name, value)) = self.header {
-            res.headers_mut().insert(name, value);
+            res.headers_mut().append(name, value);
         }
         res
     }


### PR DESCRIPTION
This change allows to set multiple header values with the same key using `warp::reply::with_header`. Previously, the old value was overwritten by the new one.