### PR TITLE
Implemented Reply for a infallible result

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -435,11 +435,7 @@ where
     fn into_response(self) -> Response {
         match self {
             Ok(t) => t.into_response(),
-            Err(e) => {
-                // Maybe panic?
-                tracing::error!("Infallible Error: {:?}", e);
-                StatusCode::INTERNAL_SERVER_ERROR.into_response()
-            }
+            Err(e) => match e {}
         }
     }
 }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -427,6 +427,23 @@ where
     }
 }
 
+impl<T> Reply for Result<T, std::convert::Infallible>
+where
+    T: Reply + Send,
+{
+    #[inline]
+    fn into_response(self) -> Response {
+        match self {
+            Ok(t) => t.into_response(),
+            Err(e) => {
+                // Maybe panic?
+                tracing::error!("Infallible Error: {:?}", e);
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+        }
+    }
+}
+
 fn text_plain<T: Into<Body>>(body: T) -> Response {
     let mut response = ::http::Response::new(body.into());
     response.headers_mut().insert(

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -435,7 +435,7 @@ where
     fn into_response(self) -> Response {
         match self {
             Ok(t) => t.into_response(),
-            Err(e) => match e {}
+            Err(e) => match e {},
         }
     }
 }


### PR DESCRIPTION
`http::Error` implements `From<Infallible>`, this just shortcuts that so we can have an easy time with infallible results.

Another option is to implement the following:
```
impl<T,E> Reply for Result<T, E>
where
    T: Reply + Send,
    E: Reply + Send,
{ ... }
```