### PR TITLE
Remove the obsolent tracing-futures dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ serde_urlencoded = "0.7"
 tokio = { version = "1.0", features = ["fs", "sync", "time"] }
 tokio-stream = "0.1.1"
 tokio-util = { version = "0.6", features = ["io"] }
-tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
-tracing-futures = { version = "0.2", default-features = false, features = ["std-future"] }
+tracing = { version = "0.1.21", default-features = false, features = ["log", "std"] }
 tower-service = "0.3"
 # tls is enabled by default, we don't want that yet
 tokio-tungstenite = { version = "0.13", default-features = false, optional = true }

--- a/src/filters/trace.rs
+++ b/src/filters/trace.rs
@@ -234,8 +234,8 @@ mod internal {
         pub(super) trace: Trace<FN>,
     }
 
+    use tracing::instrument::{Instrument, Instrumented};
     use tracing::Span;
-    use tracing_futures::{Instrument, Instrumented};
 
     fn finished_logger<E: IsReject>(reply: &Result<(Traced,), E>) {
         match reply {

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,7 +12,7 @@ use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::Server as HyperServer;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use crate::filter::Filter;
 use crate::reject::IsReject;


### PR DESCRIPTION
The `tracing-futures` dependency is no longer needed since `tracing` v0.1.21