### PR TITLE
filters: fs: end range parameter edge case

### DIFF
--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -375,7 +375,14 @@ fn bytes_range(range: Option<Range>, max_len: u64) -> Result<(u64, u64), BadRang
 
             let end = match end {
                 Bound::Unbounded => max_len,
-                Bound::Included(s) => s + 1,
+                Bound::Included(s) => {
+                    // For the special case where s == the file size
+                    if s == max_len {
+                        s
+                    } else {
+                        s + 1
+                    }
+                }
                 Bound::Excluded(s) => s,
             };
 


### PR DESCRIPTION
This fix originates from #815. 

This fixes the edge case where  the bound == file size. 
By default the bound is always incremented by one
but if it is equal to the file size it should *not* increment.