### PR TITLE
implemented Into trait for Rejection

### DIFF
--- a/src/reject.rs
+++ b/src/reject.rs
@@ -319,6 +319,14 @@ impl Rejection {
     }
 }
 
+// we cannot implement From because Response is part of hyper crate
+#[allow(clippy::from_over_into)]
+impl Into<crate::reply::Response> for Rejection {
+    fn into(self) -> crate::reply::Response {
+        self.into_response()
+    }
+}
+
 impl<T: Reject> From<T> for Rejection {
     #[inline]
     fn from(err: T) -> Rejection {


### PR DESCRIPTION
proposal for public interface to make a Response from a Rejection, using somewhat idiomatic Rust implementing the Into trait.

This is for issue #451 

In users code this would work for example:

```rust
async fn handle_rejections(
    rej: warp::reject::Rejection,
) -> Result<warp::reply::Response, std::convert::Infallible> {
    let res = if let Some(inner) = rej.find::<AuthRejections>() {
        match inner {
            AuthRejections::InvalidPassword { .. } => {
                warp_response("", "text/plain", warp::http::status::StatusCode::FORBIDDEN)
            }
            // ... other custom matches
        }
    } else {
        rej.into() // use warp implemented rejection into response here
    };
    Ok(res)
}
```