### PR TITLE
Add error source implementation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,11 @@ impl fmt::Display for Error {
     }
 }
 
-impl StdError for Error {}
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(self.inner.as_ref())
+    }
+}
 
 impl From<Infallible> for Error {
     fn from(infallible: Infallible) -> Error {
@@ -42,6 +46,12 @@ fn error_size_of() {
         ::std::mem::size_of::<Error>(),
         ::std::mem::size_of::<usize>() * 2
     );
+}
+
+#[test]
+fn error_source() {
+    let e = Error::new(std::fmt::Error{});
+    assert!(e.source().unwrap().is::<std::fmt::Error>());
 }
 
 macro_rules! unit_error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,7 @@ fn error_size_of() {
 
 #[test]
 fn error_source() {
-    let e = Error::new(std::fmt::Error{});
+    let e = Error::new(std::fmt::Error {});
     assert!(e.source().unwrap().is::<std::fmt::Error>());
 }
 


### PR DESCRIPTION
Without this it's hard to figure out in code what's the real reason for
the failure. Parsing the description is not enough.