### PR TITLE
Add pub fn to get a Response from a Rejection

### DIFF
--- a/src/reject.rs
+++ b/src/reject.rs
@@ -317,6 +317,30 @@ impl Rejection {
             false
         }
     }
+
+    /// Get the default `Response` for this `Rejection`. With a custom `Rejection`, this will
+    /// always return a response with status code `INTERNAL_SERVER_ERROR`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let rejection = warp::reject();
+    /// assert_eq!(rejection.default_response().status(), warp::http::StatusCode::NOT_FOUND);
+    ///
+    /// #[derive(Debug)]
+    /// struct MyCustomErr;
+    ///
+    /// impl warp::reject::Reject for MyCustomErr {}
+    ///
+    /// let rejection = warp::reject::custom(MyCustomErr{});
+    /// assert_eq!(
+    ///     rejection.default_response().status(),
+    ///     warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+    /// );
+    /// ```
+    pub fn default_response(&self) -> crate::reply::Response {
+        self.into_response()
+    }
 }
 
 impl<T: Reject> From<T> for Rejection {


### PR DESCRIPTION
This is inspired from my desire to easily turn a Rejection into a Response so that my recover handling code is easier. There are some routes where I want to turn all rejections into replies and not fall back to other routes, and I don't want to handle all the built-in rejections manually.

Example:

    /// My custom error type
    pub enum Error {
        // ... snip
    }

    impl warp::reject::Reject for Error {}

    pub async fn handle_rejection(
        err: Rejection
    ) -> std::result::Result<warp::reply::Response, std::convert::Infallible> {
        if let Some(e) = err.find::<Error>() {
            // handle my custom rejection
        } else {
            Ok(err.default_response())
        }
    }


My original comment:
https://github.com/seanmonstar/warp/issues/712#issuecomment-808990088