### PR TITLE
Let `unix_socket` example compile but not run on Windows

### DIFF
--- a/examples/unix_socket.rs
+++ b/examples/unix_socket.rs
@@ -1,15 +1,22 @@
 #![deny(warnings)]
 
-use tokio::net::UnixListener;
-use tokio_stream::wrappers::UnixListenerStream;
-
+#[cfg(unix)]
 #[tokio::main]
 async fn main() {
+    use tokio::net::UnixListener;
+    use tokio_stream::wrappers::UnixListenerStream;
+
     pretty_env_logger::init();
 
     let listener = UnixListener::bind("/tmp/warp.sock").unwrap();
     let incoming = UnixListenerStream::new(listener);
     warp::serve(warp::fs::dir("examples/dir"))
         .run_incoming(incoming)
-        .await;
+        .await
+}
+
+#[cfg(not(unix))]
+#[tokio::main]
+async fn main() {
+    panic!("Must run under Unix-like platform!")
 }

--- a/examples/unix_socket.rs
+++ b/examples/unix_socket.rs
@@ -12,7 +12,7 @@ async fn main() {
     let incoming = UnixListenerStream::new(listener);
     warp::serve(warp::fs::dir("examples/dir"))
         .run_incoming(incoming)
-        .await
+        .await;
 }
 
 #[cfg(not(unix))]

--- a/examples/unix_socket.rs
+++ b/examples/unix_socket.rs
@@ -18,5 +18,5 @@ async fn main() {
 #[cfg(not(unix))]
 #[tokio::main]
 async fn main() {
-    panic!("Must run under Unix-like platform!")
+    panic!("Must run under Unix-like platform!");
 }


### PR DESCRIPTION
It wasn’t possible to run the tests on Windows without this change, as the examples have to be compiled too:
```
> cargo test -- form_fields
   Compiling warp v0.3.1 (D:\Media\src\warp)
error[E0432]: unresolved import `tokio::net::UnixListener`
 --> examples\unix_socket.rs:3:5
  |
3 | use tokio::net::UnixListener;
  |     ^^^^^^^^^^^^------------
  |     |           |
  |     |           help: a similar name exists in the module: `TcpListener`
  |     no `UnixListener` in `net`

error[E0432]: unresolved import `tokio_stream::wrappers::UnixListenerStream`
 --> examples\unix_socket.rs:4:5
  |
4 | use tokio_stream::wrappers::UnixListenerStream;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^------------------
  |     |                       |
  |     |                       help: a similar name exists in the module: `TcpListenerStream`
  |     no `UnixListenerStream` in `wrappers`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0432`.
error: could not compile `warp`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```
With this change:
```
> cargo test -- form_fields
   Compiling warp v0.3.1 (D:\Media\src\warp)
    Finished test [unoptimized + debuginfo] target(s) in 42.24s
     Running unittests (target\debug\deps\warp-9e6997018269ce07.exe)
(test output elided)
```
I made it so the example `panic`s on Windows, and I used Docker to verify I’m still able to make requests over the socket on Linux as well.