### PR TITLE
Add 2h keepalive by default 

### DIFF
--- a/src/reject.rs
+++ b/src/reject.rs
@@ -362,7 +362,6 @@ impl fmt::Debug for Reason {
 }
 
 #[doc(hidden)]
-#[deprecated(note = "Use warp::reply::json and warp::reply::with_status instead.")]
 impl serde::Serialize for Rejection {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 #[cfg(feature = "tls")]
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::{Async, Future, Poll, Stream};
 use hyper::server::conn::AddrIncoming;
@@ -62,6 +63,7 @@ macro_rules! addr_incoming {
     ($addr:expr) => {{
         let mut incoming = AddrIncoming::bind($addr)?;
         incoming.set_nodelay(true);
+        incoming.set_keepalive(Some(Duration::new(7200, 0)));
         let addr = incoming.local_addr();
         (addr, incoming)
     }};


### PR DESCRIPTION
Add 2h keepalive by default to drop unused TCP sessions (e.g. behind a firewall).

Fix unused deprecation error given by new compilers.