### PR TITLE
Remove unnecessary clone in `websockets_chat.rs`

### DIFF
--- a/examples/websockets_chat.rs
+++ b/examples/websockets_chat.rs
@@ -73,9 +73,6 @@ async fn user_connected(ws: WebSocket, users: Users) {
     // Return a `Future` that is basically a state machine managing
     // this specific user's connection.
 
-    // Make an extra clone to give to our disconnection handler...
-    let users2 = users.clone();
-
     // Every time the user sends a message, broadcast it to
     // all other users...
     while let Some(result) = user_ws_rx.next().await {
@@ -91,7 +88,7 @@ async fn user_connected(ws: WebSocket, users: Users) {
 
     // user_ws_rx stream will keep processing as long as the user stays
     // connected. Once they disconnect, then...
-    user_disconnected(my_id, &users2).await;
+    user_disconnected(my_id, &users).await;
 }
 
 async fn user_message(my_id: usize, msg: Message, users: &Users) {


### PR DESCRIPTION
Hi, thanks for maintaining this great library. I think there is a line in the `websockets_chat.rs` library to clone an `Arc<_>` that isn't necessary, since the `users` variable is only passed around by a reference of type `&Arc<_>` anyway. I removed this cloned variable, and it still seems to compile and run fine.

Let me know if this makes sense.