### PR TITLE
Expose tracing/log feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_urlencoded = "0.7"
 tokio = { version = "1.0", features = ["fs", "sync", "time"] }
 tokio-stream = "0.1.1"
 tokio-util = { version = "0.6", features = ["io"] }
-tracing = { version = "0.1.21", default-features = false, features = ["log", "std"] }
+tracing = { version = "0.1.21", default-features = false, features = ["std"] }
 tower-service = "0.3"
 tokio-tungstenite = { version = "0.14", optional = true }
 percent-encoding = "2.1"
@@ -52,10 +52,11 @@ tokio-stream = { version = "0.1.1", features = ["net"] }
 listenfd = "0.3"
 
 [features]
-default = ["multipart", "websocket"]
+default = ["multipart", "websocket", "trace-log"]
 websocket = ["tokio-tungstenite"]
 tls = ["tokio-rustls"]
 compression = ["async-compression"]
+trace-log = ["tracing/log"]
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
[`log::Record`](https://docs.rs/log/0.4.14/log/struct.Record.html)'s are `!Send + !Sync` and `tracing`'s `log` feature automatically uses those, which can be problematic for consumers. Exposing the feature allows consumers to not enable the `log` feature.

The feature is called `trace-log` since both `log` and `tracing-log` are blocked by crates with the same name.