### PR TITLE
docs: Note that most futures from Server run on current runtime

### DIFF
--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -308,7 +308,7 @@ pub fn tail() -> impl Filter<Extract = One<Tail>, Error = Infallible> + Copy {
     })
 }
 
-/// Represents that tail part of a request path, returned by the `tail()` filter.
+/// Represents the tail part of a request path, returned by the [`tail()`] filter.
 pub struct Tail {
     path: PathAndQuery,
     start_index: usize,
@@ -357,7 +357,7 @@ pub fn peek() -> impl Filter<Extract = One<Peek>, Error = Infallible> + Copy {
     })
 }
 
-/// Represents that tail part of a request path, returned by the `tail()` filter.
+/// Represents the tail part of a request path, returned by the [`peek()`] filter.
 pub struct Peek {
     path: PathAndQuery,
     start_index: usize,
@@ -416,7 +416,7 @@ pub fn full() -> impl Filter<Extract = One<FullPath>, Error = Infallible> + Copy
     filter_fn(move |route| future::ok(one(FullPath(path_and_query(&route)))))
 }
 
-/// Represents the full request path, returned by the `full()` filter.
+/// Represents the full request path, returned by the [`full()`] filter.
 pub struct FullPath(PathAndQuery);
 
 impl FullPath {

--- a/src/server.rs
+++ b/src/server.rs
@@ -165,7 +165,7 @@ where
     }
 
     /// Bind to a socket address, returning a `Future` that can be
-    /// executed on any runtime.
+    /// executed on the current runtime.
     ///
     /// # Panics
     ///
@@ -201,7 +201,7 @@ where
     /// Bind to a possibly ephemeral socket address.
     ///
     /// Returns the bound address and a `Future` that can be executed on
-    /// any runtime.
+    /// the current runtime.
     ///
     /// # Panics
     ///
@@ -226,7 +226,7 @@ where
     /// underlying error.
     ///
     /// Returns the bound address and a `Future` that can be executed on
-    /// any runtime.
+    /// the current runtime.
     pub fn try_bind_ephemeral(
         self,
         addr: impl Into<SocketAddr>,
@@ -248,7 +248,7 @@ where
     /// process.
     ///
     /// Returns the bound address and a `Future` that can be executed on
-    /// any runtime.
+    /// the current runtime.
     ///
     /// # Example
     ///
@@ -313,7 +313,7 @@ where
     ///
     /// This can be used for Unix Domain Sockets, or TLS, etc.
     ///
-    /// Returns a `Future` that can be executed on any runtime.
+    /// Returns a `Future` that can be executed on the current runtime.
     pub fn serve_incoming<I>(self, incoming: I) -> impl Future<Output = ()>
     where
         I: TryStream + Send,
@@ -333,7 +333,7 @@ where
     /// When the signal completes, the server will start the graceful shutdown
     /// process.
     ///
-    /// Returns a `Future` that can be executed on any runtime.
+    /// Returns a `Future` that can be executed on the current runtime.
     pub fn serve_incoming_with_graceful_shutdown<I>(
         self,
         incoming: I,
@@ -524,7 +524,7 @@ where
     /// Bind to a possibly ephemeral socket address.
     ///
     /// Returns the bound address and a `Future` that can be executed on
-    /// any runtime.
+    /// the current runtime.
     ///
     /// *This function requires the `"tls"` feature.*
     pub fn bind_ephemeral(


### PR DESCRIPTION
The documentation for most of the warp::Server methods (bind,
try_bind_with_graceful_shutdown, etc) indicate that the futures
they return can be run on any runtime. However, these functions
panic if they are called outside the context of a Tokio 1.x runtime.

This commit makes a minor update to the documentation to note that
these function return futures that run on the /current/ runtime.

Note that try_bind can actually be called outside the context of a
Tokio runtime, so the docstring for that method remains unchanged.