### PR TITLE
Expose `FilterBase` to cargo doc

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 mod and;
 mod and_then;
 mod boxed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,8 @@ mod transport;
 
 pub use self::error::Error;
 pub use self::filter::Filter;
+#[cfg(doc)]
+pub use crate::filter::FilterBase;
 // This otherwise shows a big dump of re-exports in the doc homepage,
 // with zero context, so just hide it from the docs. Doc examples
 // on each can show that a convenient import exists.


### PR DESCRIPTION
So when trying to pass a filter as an argument to a function I was struggling to get the trait bounds to work generically going off the compiler error messages or published documentation. I asked on the discord and got the answer and looking at the code it is clear what the solution was but the documentation could be more helpful but this is kind of complicated by the `FilterBase` trait being private. @Kestrer suggested doing a PR to expose `FilterBase` just in docs so here it is. I guess the one concern is maybe the docs as they would be after this change may need some more big bold text to tell people `FilterBase` isn't available for them to use and they shouldn't rely on it's implementation details. Potentially `#[doc(hidden)]` on the trait methods so only the `Extract` and `Rejection` types are shown in the documentation?

The documentation before:

![Before](https://user-images.githubusercontent.com/3472518/123134584-dae35f00-d448-11eb-8d65-4d68143880f7.png)

The documentation after showing me the `Extract` value I needed to get my code to work

![After](https://user-images.githubusercontent.com/3472518/123134777-0bc39400-d449-11eb-950e-818c14bd974f.png)
