### PR TITLE
Use stabilized `Poll::map_err` on compression filter stream

### DIFF
--- a/src/filters/compression.rs
+++ b/src/filters/compression.rs
@@ -183,9 +183,7 @@ mod internal {
             use std::io::{Error, ErrorKind};
 
             let pin = self.project();
-            // TODO: Use `.map_err()` (https://github.com/rust-lang/rust/issues/63514) once it is stabilized
-            S::poll_next(pin.body, cx)
-                .map(|e| e.map(|res| res.map_err(|_| Error::from(ErrorKind::InvalidData))))
+            S::poll_next(pin.body, cx).map_err(|_| Error::from(ErrorKind::InvalidData))
         }
     }
 


### PR DESCRIPTION
This PR just does a small upgrade of [`Poll::map_err`](https://doc.rust-lang.org/std/task/enum.Poll.html#method.map_err-1) which is stabilized since 1.51.0.

https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25
