### PR TITLE
Add support for custom HTTP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.x.x (TBD)
+- **Features**:
+  - Add `custom_method` filter.
+
 ### v0.3.1 (March 24, 2021)
 
 - **Features**:

--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -40,7 +40,7 @@ use tokio_tungstenite::{
 /// - Header `connection: upgrade`
 /// - Header `upgrade: websocket`
 /// - Header `sec-websocket-accept` with the hash value of the received key.
-pub fn ws() -> impl Filter<Extract = One<Ws>, Error = Rejection> + Copy {
+pub fn ws() -> impl Filter<Extract = One<Ws>, Error = Rejection> + Clone {
     let connection_has_upgrade = header::header2()
         .and_then(|conn: ::headers::Connection| {
             if conn.contains("upgrade") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub use self::filters::{
     log,
     // log() function
     log::log,
-    method::{delete, get, head, method, options, patch, post, put},
+    method::{custom_method, delete, get, head, method, options, patch, post, put},
     path,
     // path() function and macro
     path::path,


### PR DESCRIPTION
Fixes #871.

I had to turn all method filters from `Copy` to `Clone` because custom `Method`s cannot be created as `const`, which makes passing them as `&'static` impossible in practice (or at least, I couldn't figure out a way to do it).