### PR TITLE
Implemented `Filter::then`

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -7,6 +7,7 @@ mod or;
 mod or_else;
 mod recover;
 pub(crate) mod service;
+mod then;
 mod unify;
 mod untuple_one;
 mod wrap;
@@ -27,6 +28,7 @@ pub(crate) use self::map_err::MapErr;
 pub(crate) use self::or::Or;
 use self::or_else::OrElse;
 use self::recover::Recover;
+use self::then::Then;
 use self::unify::Unify;
 use self::untuple_one::UntupleOne;
 pub use self::wrap::wrap_fn;
@@ -197,12 +199,44 @@ pub trait Filter: FilterBase {
         }
     }
 
-    /// Composes this `Filter` with a function receiving the extracted value.
+    /// Composes this `Filter` with an async function receiving
+    /// the extracted value.
+    ///
+    /// The function should return some `Future` type.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use warp::Filter;
+    ///
+    /// // Map `/:id`
+    /// warp::path::param().then(|id: u64| async move {
+    ///   format!("Hello #{}", id)
+    /// });
+    /// ```
+    fn then<F>(self, fun: F) -> Then<Self, F>
+    where
+        Self: Sized,
+        F: Func<Self::Extract> + Clone,
+        F::Output: Future + Send,
+    {
+        Then {
+            filter: self,
+            callback: fun,
+        }
+    }
+
+    /// Composes this `Filter` with a fallible async function receiving
+    /// the extracted value.
     ///
     /// The function should return some `TryFuture` type.
     ///
     /// The `Error` type of the return `Future` needs be a `Rejection`, which
     /// means most futures will need to have their error mapped into one.
+    ///
+    /// Rejections are meant to say "this filter didn't accept the request,
+    /// maybe another can". So for application-level errors, consider using
+    /// [`Filter::then`] instead.
     ///
     /// # Example
     ///

--- a/src/filter/then.rs
+++ b/src/filter/then.rs
@@ -6,27 +6,25 @@ use futures::{ready, TryFuture};
 use pin_project::pin_project;
 
 use super::{Filter, FilterBase, Func, Internal};
-use crate::reject::CombineRejection;
 
 #[derive(Clone, Copy, Debug)]
-pub struct AndThen<T, F> {
+pub struct Then<T, F> {
     pub(super) filter: T,
     pub(super) callback: F,
 }
 
-impl<T, F> FilterBase for AndThen<T, F>
+impl<T, F> FilterBase for Then<T, F>
 where
     T: Filter,
     F: Func<T::Extract> + Clone + Send,
-    F::Output: TryFuture + Send,
-    <F::Output as TryFuture>::Error: CombineRejection<T::Error>,
+    F::Output: Future + Send,
 {
-    type Extract = (<F::Output as TryFuture>::Ok,);
-    type Error = <<F::Output as TryFuture>::Error as CombineRejection<T::Error>>::One;
-    type Future = AndThenFuture<T, F>;
+    type Extract = (<F::Output as Future>::Output,);
+    type Error = T::Error;
+    type Future = ThenFuture<T, F>;
     #[inline]
     fn filter(&self, _: Internal) -> Self::Future {
-        AndThenFuture {
+        ThenFuture {
             state: State::First(self.filter.filter(Internal), self.callback.clone()),
         }
     }
@@ -34,12 +32,11 @@ where
 
 #[allow(missing_debug_implementations)]
 #[pin_project]
-pub struct AndThenFuture<T, F>
+pub struct ThenFuture<T, F>
 where
     T: Filter,
     F: Func<T::Extract>,
-    F::Output: TryFuture + Send,
-    <F::Output as TryFuture>::Error: CombineRejection<T::Error>,
+    F::Output: Future + Send,
 {
     #[pin]
     state: State<T::Future, F>,
@@ -50,25 +47,20 @@ enum State<T, F>
 where
     T: TryFuture,
     F: Func<T::Ok>,
-    F::Output: TryFuture + Send,
-    <F::Output as TryFuture>::Error: CombineRejection<T::Error>,
+    F::Output: Future + Send,
 {
     First(#[pin] T, F),
     Second(#[pin] F::Output),
     Done,
 }
 
-impl<T, F> Future for AndThenFuture<T, F>
+impl<T, F> Future for ThenFuture<T, F>
 where
     T: Filter,
     F: Func<T::Extract>,
-    F::Output: TryFuture + Send,
-    <F::Output as TryFuture>::Error: CombineRejection<T::Error>,
+    F::Output: Future + Send,
 {
-    type Output = Result<
-        (<F::Output as TryFuture>::Ok,),
-        <<F::Output as TryFuture>::Error as CombineRejection<T::Error>>::One,
-    >;
+    type Output = Result<(<F::Output as Future>::Output,), T::Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         self.project().state.poll(cx)
@@ -79,13 +71,9 @@ impl<T, F> Future for State<T, F>
 where
     T: TryFuture,
     F: Func<T::Ok>,
-    F::Output: TryFuture + Send,
-    <F::Output as TryFuture>::Error: CombineRejection<T::Error>,
+    F::Output: Future + Send,
 {
-    type Output = Result<
-        (<F::Output as TryFuture>::Ok,),
-        <<F::Output as TryFuture>::Error as CombineRejection<T::Error>>::One,
-    >;
+    type Output = Result<(<F::Output as Future>::Output,), T::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         loop {
@@ -96,12 +84,9 @@ where
                     self.set(State::Second(fut2));
                 }
                 StateProj::Second(second) => {
-                    let ex2 = match ready!(second.try_poll(cx)) {
-                        Ok(item) => Ok((item,)),
-                        Err(err) => Err(From::from(err)),
-                    };
+                    let ex2 = (ready!(second.poll(cx)),);
                     self.set(State::Done);
-                    return Poll::Ready(ex2);
+                    return Poll::Ready(Ok(ex2));
                 }
                 StateProj::Done => panic!("polled after complete"),
             }


### PR DESCRIPTION
Tipping point for me to jump into `Future` type hell to implement this was [this](https://github.com/seanmonstar/warp/issues/712#issuecomment-697031645) comment - but I'd say it's worth it. I've used it in my personal project for a while, and the code I've been able to write is much cleaner, I think.

Changes:
- Added `Filter::then()` and complementary type `Then`. Exactly like `map`, but async. The name is meant to reflect [future's `then()`](https://docs.rs/futures/0.3.17/futures/future/trait.FutureExt.html#method.then) function.
- `Filter::and_then()` documentation now points to `Filter::then()` as an alternative, since my understanding is that:
   > Rejections are meant to say "this filter didn't accept the request, maybe another can." 

Fix #712
Fix #594

Providing Reply implementations for Result would also be very useful, so this is loosely related to #458

---

Post-edit note: This function was renamed from `map_async` to `then` to more closely match `future`'s api. However it is worth noting that just as `Filter::map` isn't exactly like `future`'s `map` on account of rejections, `Filter::then` isn't exactly like `future`'s `then`. However `Filter::then` is the same, conceptually, as `future`'s `then`, so this seems like the best choice.