### PR TITLE
Upgrade tokio-tungstenite to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tokio-stream = "0.1.1"
 tokio-util = { version = "0.6", features = ["io"] }
 tracing = { version = "0.1.21", default-features = false, features = ["std"] }
 tower-service = "0.3"
-tokio-tungstenite = { version = "0.14", optional = true }
+tokio-tungstenite = { version = "0.15", optional = true }
 percent-encoding = "2.1"
 pin-project = "1.0"
 tokio-rustls = { version = "0.22", optional = true }


### PR DESCRIPTION
Hi, thanks for maintaining this great project!

The tokio-tungstenite library was recently updated to version 0.15 which includes some performance improvements over version 0.14. In my test setup, which uses "websocat" to send messages to the bundled example echo-server ("examples/websocket.rs"), the throughput with version 0.15 is improved from about 60 MB/s to 80MB/s with a single connection.
Using several parallel connections maxes out the network bandwidth so the total transfer time is about the same, but the CPU load on the server is consistently lower (~50% CPU idle according to "top" with tokio-tungstenite 0.15, compared to ~35% idle with version 0.14). The echo-server was run on a Raspberry Pi 4 with the standard Raspberry Pi OS.

I thought it might be worthwhile to update to this new version, unless there are other reasons for why it might not be desirable.
Please let me know what you think.