### PR TITLE
Make TLS ciphersuites configurable

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -12,6 +12,8 @@ use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::Server as HyperServer;
 use tokio::io::{AsyncRead, AsyncWrite};
+#[cfg(feature = "tls")]
+use tokio_rustls::rustls::SupportedCipherSuite;
 use tracing::Instrument;
 
 use crate::filter::Filter;
@@ -488,6 +490,13 @@ where
     /// *This function requires the `"tls"` feature.*
     pub fn ocsp_resp(self, resp: impl AsRef<[u8]>) -> Self {
         self.with_tls(|tls| tls.ocsp_resp(resp.as_ref()))
+    }
+
+    /// Specify the ciphersuites to use in preference order.
+    ///
+    /// *This function requires the `"tls"` feature.*
+    pub fn ciphersuites(self, ciphersuites: impl AsRef<[&'static SupportedCipherSuite]>) -> Self {
+        self.with_tls(|tls| tls.ciphersuites(ciphersuites.as_ref()))
     }
 
     fn with_tls<Func>(self, func: Func) -> Self

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -15,7 +15,7 @@ use hyper::server::conn::{AddrIncoming, AddrStream};
 use crate::transport::Transport;
 use tokio_rustls::rustls::{
     AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
-    RootCertStore, ServerConfig, TLSError,
+    RootCertStore, ServerConfig, SupportedCipherSuite, TLSError, ALL_CIPHERSUITES,
 };
 
 /// Represents errors that can occur building the TlsConfig
@@ -65,6 +65,7 @@ pub(crate) struct TlsConfigBuilder {
     key: Box<dyn Read + Send + Sync>,
     client_auth: TlsClientAuth,
     ocsp_resp: Vec<u8>,
+    ciphersuites: Vec<&'static SupportedCipherSuite>,
 }
 
 impl std::fmt::Debug for TlsConfigBuilder {
@@ -81,6 +82,7 @@ impl TlsConfigBuilder {
             cert: Box::new(io::empty()),
             client_auth: TlsClientAuth::Off,
             ocsp_resp: Vec::new(),
+            ciphersuites: ALL_CIPHERSUITES.to_vec(),
         }
     }
 
@@ -166,6 +168,12 @@ impl TlsConfigBuilder {
         self
     }
 
+    /// sets the ciphersuites in preference order
+    pub(crate) fn ciphersuites(mut self, ciphersuites: &[&'static SupportedCipherSuite]) -> Self {
+        self.ciphersuites = Vec::from(ciphersuites);
+        self
+    }
+
     pub(crate) fn build(mut self) -> Result<ServerConfig, TlsConfigError> {
         let mut cert_rdr = BufReader::new(self.cert);
         let cert = tokio_rustls::rustls::internal::pemfile::certs(&mut cert_rdr)
@@ -225,7 +233,8 @@ impl TlsConfigBuilder {
             }
         };
 
-        let mut config = ServerConfig::new(client_auth);
+        let ciphersuites = self.ciphersuites.as_ref();
+        let mut config = ServerConfig::with_ciphersuites(client_auth, ciphersuites);
         config
             .set_single_cert_with_ocsp_and_sct(cert, key, self.ocsp_resp, Vec::new())
             .map_err(|err| TlsConfigError::InvalidKey(err))?;


### PR DESCRIPTION
Hello, I would like to make the TLS ciphersuites configurable. Let me know how to proceed if you are not comfortable to expose `SupportedCipherSuite` from `rustls`.