### PR TITLE
Document tls example with compilation instruction

### DIFF
--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -2,6 +2,7 @@
 
 // Don't copy this `cfg`, it's only needed because this file is within
 // the warp repository.
+// Instead, specify the "tls" feature in your warp dependency declaration.
 #[cfg(feature = "tls")]
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
It was clear that I didn't need the `#[cfg(feature ...)]` in order to get
a `Server` that could respond to `.tls()`, but I wasn't immediately sure if
just adding the tls feature to the warp dependency (in Cargo.toml) was
enough, or I had to specify some transitive dependency with it, or
something else. And as the feature wasn't enabled, the docs produced
with `cargo doc --workspace` didn't include `Server.tls`, so I started to
question if the example I was looking at even matched the warp version
I was working with.

Eventually I just tried adding it to the warp dep and it (of course)
just worked, but for the sake of others I reckon a more explicit
pointing in the right direction could be helpful.