### PR TITLE
Replace `futures` with `futures-util`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 [dependencies]
 async-compression = { version = "0.3.7", features = ["brotli", "deflate", "gzip", "tokio"], optional = true }
 bytes = "1.0"
-futures = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3", default-features = false }
 headers = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["stream", "server", "http1", "tcp", "client"] }

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures_util::StreamExt;
 use std::convert::Infallible;
 use std::time::Duration;
 use tokio::time::interval;

--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -1,4 +1,4 @@
-use futures::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt};
 use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},

--- a/examples/websockets.rs
+++ b/examples/websockets.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 
-use futures::{FutureExt, StreamExt};
+use futures_util::{FutureExt, StreamExt};
 use warp::Filter;
 
 #[tokio::main]

--- a/examples/websockets_chat.rs
+++ b/examples/websockets_chat.rs
@@ -5,7 +5,7 @@ use std::sync::{
     Arc,
 };
 
-use futures::{SinkExt, StreamExt, TryFutureExt};
+use futures_util::{SinkExt, StreamExt, TryFutureExt};
 use tokio::sync::{mpsc, RwLock};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use warp::ws::{Message, WebSocket};

--- a/src/filter/and.rs
+++ b/src/filter/and.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::ready;
+use futures_util::ready;
 use pin_project::pin_project;
 
 use super::{Combine, Filter, FilterBase, Internal, Tuple};

--- a/src/filter/and_then.rs
+++ b/src/filter/and_then.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::{ready, TryFuture};
+use futures_util::{ready, TryFuture};
 use pin_project::pin_project;
 
 use super::{Filter, FilterBase, Func, Internal};

--- a/src/filter/boxed.rs
+++ b/src/filter/boxed.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use futures::TryFutureExt;
+use futures_util::TryFutureExt;
 
 use super::{Filter, FilterBase, Internal, Tuple};
 use crate::reject::Rejection;

--- a/src/filter/map.rs
+++ b/src/filter/map.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::{ready, TryFuture};
+use futures_util::{ready, TryFuture};
 use pin_project::pin_project;
 
 use super::{Filter, FilterBase, Func, Internal};

--- a/src/filter/map_err.rs
+++ b/src/filter/map_err.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::TryFuture;
+use futures_util::TryFuture;
 use pin_project::pin_project;
 
 use super::{Filter, FilterBase, Internal};

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -14,7 +14,7 @@ mod wrap;
 
 use std::future::Future;
 
-use futures::{future, TryFuture, TryFutureExt};
+use futures_util::{future, TryFuture, TryFutureExt};
 
 pub(crate) use crate::generic::{one, Combine, Either, Func, One, Tuple};
 use crate::reject::{CombineRejection, IsReject, Rejection};

--- a/src/filter/or.rs
+++ b/src/filter/or.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::{ready, TryFuture};
+use futures_util::{ready, TryFuture};
 use pin_project::pin_project;
 
 use super::{Filter, FilterBase, Internal};

--- a/src/filter/or_else.rs
+++ b/src/filter/or_else.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::{ready, TryFuture};
+use futures_util::{ready, TryFuture};
 use pin_project::pin_project;
 
 use super::{Filter, FilterBase, Func, Internal};

--- a/src/filter/recover.rs
+++ b/src/filter/recover.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::{ready, TryFuture};
+use futures_util::{ready, TryFuture};
 use pin_project::pin_project;
 
 use super::{Filter, FilterBase, Func, Internal};

--- a/src/filter/service.rs
+++ b/src/filter/service.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::future::TryFuture;
+use futures_util::future::TryFuture;
 use hyper::service::Service;
 use pin_project::pin_project;
 

--- a/src/filter/then.rs
+++ b/src/filter/then.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::{ready, TryFuture};
+use futures_util::{ready, TryFuture};
 use pin_project::pin_project;
 
 use super::{Filter, FilterBase, Func, Internal};

--- a/src/filter/unify.rs
+++ b/src/filter/unify.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::{ready, TryFuture};
+use futures_util::{ready, TryFuture};
 use pin_project::pin_project;
 
 use super::{Either, Filter, FilterBase, Internal, Tuple};

--- a/src/filter/untuple_one.rs
+++ b/src/filter/untuple_one.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::{ready, TryFuture};
+use futures_util::{ready, TryFuture};
 use pin_project::pin_project;
 
 use super::{Filter, FilterBase, Internal, Tuple};

--- a/src/filters/addr.rs
+++ b/src/filters/addr.rs
@@ -22,5 +22,5 @@ use crate::filter::{filter_fn_one, Filter};
 ///     });
 /// ```
 pub fn remote() -> impl Filter<Extract = (Option<SocketAddr>,), Error = Infallible> + Copy {
-    filter_fn_one(|route| futures::future::ok(route.remote_addr()))
+    filter_fn_one(|route| futures_util::future::ok(route.remote_addr()))
 }

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -8,7 +8,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use bytes::{Buf, Bytes};
-use futures::{future, ready, Stream, TryFutureExt};
+use futures_util::{future, ready, Stream, TryFutureExt};
 use headers::ContentLength;
 use http::header::CONTENT_TYPE;
 use hyper::Body;

--- a/src/filters/compression.rs
+++ b/src/filters/compression.rs
@@ -149,7 +149,7 @@ mod internal {
     use std::task::{Context, Poll};
 
     use bytes::Bytes;
-    use futures::{ready, Stream, TryFuture};
+    use futures_util::{ready, Stream, TryFuture};
     use hyper::Body;
     use pin_project::pin_project;
 

--- a/src/filters/cookie.rs
+++ b/src/filters/cookie.rs
@@ -1,6 +1,6 @@
 //! Cookie Filters
 
-use futures::future;
+use futures_util::future;
 use headers::Cookie;
 
 use super::header;

--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -459,7 +459,7 @@ mod internal {
     use std::sync::Arc;
     use std::task::{Context, Poll};
 
-    use futures::{future, ready, TryFuture};
+    use futures_util::{future, ready, TryFuture};
     use headers::Origin;
     use http::header;
     use pin_project::pin_project;

--- a/src/filters/ext.rs
+++ b/src/filters/ext.rs
@@ -2,7 +2,7 @@
 
 use std::convert::Infallible;
 
-use futures::future;
+use futures_util::future;
 
 use crate::filter::{filter_fn_one, Filter};
 use crate::reject::{self, Rejection};

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use std::task::Poll;
 
 use bytes::{Bytes, BytesMut};
-use futures::future::Either;
-use futures::{future, ready, stream, FutureExt, Stream, StreamExt, TryFutureExt};
+use futures_util::future::Either;
+use futures_util::{future, ready, stream, FutureExt, Stream, StreamExt, TryFutureExt};
 use headers::{
     AcceptRanges, ContentLength, ContentRange, ContentType, HeaderMapExt, IfModifiedSince, IfRange,
     IfUnmodifiedSince, LastModified, Range,

--- a/src/filters/header.rs
+++ b/src/filters/header.rs
@@ -7,7 +7,7 @@
 use std::convert::Infallible;
 use std::str::FromStr;
 
-use futures::future;
+use futures_util::future;
 use headers::{Header, HeaderMapExt};
 use http::header::HeaderValue;
 use http::HeaderMap;

--- a/src/filters/host.rs
+++ b/src/filters/host.rs
@@ -2,7 +2,7 @@
 //!
 use crate::filter::{filter_fn_one, Filter, One};
 use crate::reject::{self, Rejection};
-use futures::future;
+use futures_util::future;
 pub use http::uri::Authority;
 use std::str::FromStr;
 

--- a/src/filters/log.rs
+++ b/src/filters/log.rs
@@ -187,7 +187,7 @@ mod internal {
     use std::task::{Context, Poll};
     use std::time::Instant;
 
-    use futures::{ready, TryFuture};
+    use futures_util::{ready, TryFuture};
     use pin_project::pin_project;
 
     use super::{Info, Log};

--- a/src/filters/method.rs
+++ b/src/filters/method.rs
@@ -6,7 +6,7 @@
 //!
 //! There is also [`warp::method()`](method), which never rejects
 //! a request, and just extracts the method to be used in your filter chains.
-use futures::future;
+use futures_util::future;
 use http::Method;
 
 use crate::filter::{filter_fn, filter_fn_one, Filter, One};

--- a/src/filters/multipart.rs
+++ b/src/filters/multipart.rs
@@ -9,7 +9,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use bytes::{Buf, Bytes};
-use futures::{future, Stream};
+use futures_util::{future, Stream};
 use headers::ContentType;
 use mime::Mime;
 use multipart::server::Multipart;

--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -129,7 +129,7 @@ use std::convert::Infallible;
 use std::fmt;
 use std::str::FromStr;
 
-use futures::future;
+use futures_util::future;
 use http::uri::PathAndQuery;
 
 use self::internal::Opaque;

--- a/src/filters/query.rs
+++ b/src/filters/query.rs
@@ -1,6 +1,6 @@
 //! Query Filters
 
-use futures::future;
+use futures_util::future;
 use serde::de::DeserializeOwned;
 use serde_urlencoded;
 

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -7,7 +7,7 @@
 //! use std::time::Duration;
 //! use std::convert::Infallible;
 //! use warp::{Filter, sse::Event};
-//! use futures::{stream::iter, Stream};
+//! use futures_util::{stream::iter, Stream};
 //!
 //! fn sse_events() -> impl Stream<Item = Result<Event, Infallible>> {
 //!     iter(vec![
@@ -49,7 +49,7 @@ use std::str::FromStr;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use futures::{future, Stream, TryStream, TryStreamExt};
+use futures_util::{future, Stream, TryStream, TryStreamExt};
 use http::header::{HeaderValue, CACHE_CONTROL, CONTENT_TYPE};
 use hyper::Body;
 use pin_project::pin_project;
@@ -244,8 +244,8 @@ where
 /// ```
 ///
 /// use std::time::Duration;
-/// use futures::Stream;
-/// use futures::stream::iter;
+/// use futures_util::Stream;
+/// use futures_util::stream::iter;
 /// use std::convert::Infallible;
 /// use warp::{Filter, sse::Event};
 /// use serde_derive::Serialize;
@@ -419,7 +419,7 @@ struct SseKeepAlive<S> {
 /// ```
 /// use std::time::Duration;
 /// use std::convert::Infallible;
-/// use futures::StreamExt;
+/// use futures_util::StreamExt;
 /// use tokio::time::interval;
 /// use tokio_stream::wrappers::IntervalStream;
 /// use warp::{Filter, Stream, sse::Event};

--- a/src/filters/trace.rs
+++ b/src/filters/trace.rs
@@ -208,7 +208,7 @@ impl<'a> Info<'a> {
 }
 
 mod internal {
-    use futures::{future::Inspect, future::MapOk, FutureExt, TryFutureExt};
+    use futures_util::{future::Inspect, future::MapOk, FutureExt, TryFutureExt};
 
     use super::{Info, Trace};
     use crate::filter::{Filter, FilterBase, Internal};

--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -10,7 +10,7 @@ use super::header;
 use crate::filter::{filter_fn_one, Filter, One};
 use crate::reject::Rejection;
 use crate::reply::{Reply, Response};
-use futures::{future, ready, FutureExt, Sink, Stream, TryFutureExt};
+use futures_util::{future, ready, FutureExt, Sink, Stream, TryFutureExt};
 use headers::{Connection, HeaderMapExt, SecWebsocketAccept, SecWebsocketKey, Upgrade};
 use http;
 use hyper::upgrade::OnUpgrade;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ pub use hyper;
 #[doc(hidden)]
 pub use bytes::Buf;
 #[doc(hidden)]
-pub use futures::{Future, Sink, Stream};
+pub use futures_util::{Future, Sink, Stream};
 #[doc(hidden)]
 
 pub(crate) type Request = http::Request<hyper::Body>;

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 #[cfg(feature = "tls")]
 use std::path::Path;
 
-use futures::{future, FutureExt, TryFuture, TryStream, TryStreamExt};
+use futures_util::{future, FutureExt, TryFuture, TryStream, TryStreamExt};
 use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::Server as HyperServer;
@@ -254,7 +254,7 @@ where
     ///
     /// ```no_run
     /// use warp::Filter;
-    /// use futures::future::TryFutureExt;
+    /// use futures_util::future::TryFutureExt;
     /// use tokio::sync::oneshot;
     ///
     /// # fn main() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -93,8 +93,8 @@ use std::task::{self, Poll};
 
 use bytes::Bytes;
 #[cfg(feature = "websocket")]
-use futures::StreamExt;
-use futures::{future, FutureExt, TryFutureExt};
+use futures_util::StreamExt;
+use futures_util::{future, FutureExt, TryFutureExt};
 use http::{
     header::{HeaderName, HeaderValue},
     Response,
@@ -460,7 +460,7 @@ impl WsBuilder {
     /// # Example
     ///
     /// ```no_run
-    /// use futures::future;
+    /// use futures_util::future;
     /// use warp::Filter;
     /// #[tokio::main]
     /// # async fn main() {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-use futures::ready;
+use futures_util::ready;
 use hyper::server::accept::Accept;
 use hyper::server::conn::{AddrIncoming, AddrStream};
 

--- a/tests/body.rs
+++ b/tests/body.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 use bytes::Buf;
-use futures::TryStreamExt;
+use futures_util::TryStreamExt;
 use warp::Filter;
 
 #[tokio::test]

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 use bytes::BufMut;
-use futures::{TryFutureExt, TryStreamExt};
+use futures_util::{TryFutureExt, TryStreamExt};
 use warp::{multipart, Filter};
 
 #[tokio::test]

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -2,7 +2,7 @@
 #[macro_use]
 extern crate warp;
 
-use futures::future;
+use futures_util::future;
 use warp::Filter;
 
 #[tokio::test]

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 
-use futures::{FutureExt, SinkExt, StreamExt};
+use futures_util::{FutureExt, SinkExt, StreamExt};
 use serde_derive::Deserialize;
 use warp::ws::Message;
 use warp::Filter;


### PR DESCRIPTION
Replace usage of `futures` with `futures-util` crate.

- `cargo tree` looks much cleaner
- Removes unused `futures-io` dependency.