### PR TITLE
Implement Sink and Stream for WsClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ all-features = true
 async-compression = { version = "0.3.7", features = ["brotli", "deflate", "gzip", "tokio"], optional = true }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
+futures-channel = { version = "0.3.17", features = ["sink"]}
 headers = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["stream", "server", "http1", "tcp", "client"] }

--- a/src/test.rs
+++ b/src/test.rs
@@ -623,31 +623,31 @@ impl fmt::Debug for WsClient {
 
 #[cfg(feature = "websocket")]
 impl Sink<crate::ws::Message> for WsClient {
-    type Error = ();
+    type Error = WsError;
 
     fn poll_ready(
         self: Pin<&mut Self>,
         context: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        self.pinned_tx().poll_ready(context).map_err(|_| ())
+        self.pinned_tx().poll_ready(context).map_err(WsError::new)
     }
 
     fn start_send(self: Pin<&mut Self>, message: Message) -> Result<(), Self::Error> {
-        self.pinned_tx().start_send(message).map_err(|_| ())
+        self.pinned_tx().start_send(message).map_err(WsError::new)
     }
 
     fn poll_flush(
         self: Pin<&mut Self>,
         context: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        self.pinned_tx().poll_flush(context).map_err(|_| ())
+        self.pinned_tx().poll_flush(context).map_err(WsError::new)
     }
 
     fn poll_close(
         self: Pin<&mut Self>,
         context: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        self.pinned_tx().poll_close(context).map_err(|_| ())
+        self.pinned_tx().poll_close(context).map_err(WsError::new)
     }
 }
 

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -82,6 +82,21 @@ async fn binary() {
 }
 
 #[tokio::test]
+async fn wsclient_sink_and_stream() {
+    let _ = pretty_env_logger::try_init();
+
+    let mut client = warp::test::ws()
+        .handshake(ws_echo())
+        .await
+        .expect("handshake");
+
+    let message = warp::ws::Message::text("hello");
+    SinkExt::send(&mut client, message.clone()).await.unwrap();
+    let received_message = client.next().await.unwrap().unwrap();
+    assert_eq!(message, received_message);
+}
+
+#[tokio::test]
 async fn close_frame() {
     let _ = pretty_env_logger::try_init();
 


### PR DESCRIPTION
This implements `Sink` and `Stream` for `WsClient`.

### Why is this useful?
If you use `tokio-tungstenite` as your websocket client, you will usually have a `tokio-tungstenite::WebSocketStream` to work with, which exclusively uses the `Sink` and `Stream` traits for sending and receiving messages. Implementing `Sink` and `Stream` for `WsClient` as well allows for writing code that works with both the real `tokio-tungstenite::WebSocketStream` and `WsClient` by relying only on the `Sink` and `Stream` traits in the implementation, especially if you combine it with #903 which provides conversions between `warp::ws::Message` and `tungstenite::protocol::Message`.

### Why not use `tokio::sync::mpsc::unbounded_channel`
Initially I tried to implement this using the tokio mpsc channels that `WsClient` was using, but found it to be impossible.
Implementing `Stream` isn't an issue because of the `Stream` implementation provided in `tokio-stream` and because `tokio::sync::mpsc::UnboundedReceiver` has a `poll_recv` method exactly for that purpose.
Implementing `Sink` however doesn't work because there is no way that `poll_flush` or `poll_close` can notify a task to be polled again.

Therefore this PR switches the channel implementation from `tokio` to `futures`, since `futues::channel::mpsc::UnboundedSender` and `UnboundedReceiver` already implement `Sink` and `Stream` and the implementation on `WsClient` then only need to proxy their calls to the underlying channel.
