### PR TITLE
Feat: split compression features for Gzip and Brotli support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-async-compression = { version = "0.3.7", features = ["brotli", "deflate", "gzip", "tokio"], optional = true }
+async-compression = { version = "0.3.7", features = ["tokio"], optional = true }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 futures-channel = { version = "0.3.17", features = ["sink"]}
@@ -56,7 +56,11 @@ listenfd = "0.3"
 default = ["multipart", "websocket"]
 websocket = ["tokio-tungstenite"]
 tls = ["tokio-rustls"]
-compression = ["async-compression"]
+
+# Enable compression-related filters
+compression = ["compression-brotli", "compression-gzip"]
+compression-brotli = ["async-compression/brotli"]
+compression-gzip = ["async-compression/deflate", "async-compression/gzip"]
 
 [profile.release]
 codegen-units = 1

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -6,7 +6,7 @@
 pub mod addr;
 pub mod any;
 pub mod body;
-#[cfg(feature = "compression")]
+#[cfg(any(feature = "compression-brotli", feature = "compression-gzip"))]
 pub mod compression;
 pub mod cookie;
 pub mod cors;


### PR DESCRIPTION
Hello there! This PR splits the `compression` feature into two: `compression-brotli` (Brotli) and `compression-gzip` (Deflate and Gzip). As their names suggest, each feature is responsible for enabling support for their respective compression algorithms.

This is done in an effort to minimize the `cargo tree` for those who do not intend to use one or the other. Allowing the `warp` consumer to choose which compression algorithms to support gives finer-grained control over their dependencies, which is nice!

The `async-compression` crate pulls in the `brotli` crate when that feature is enabled. Similarly, it pulls in the `flate2` crate when the `deflate` feature or the `gzip` feature is enabled. Observe that the `deflate` and `gzip` features have been merged as the `compression-gzip` feature in `warp` since they both indirectly pull in the `flate2` crate anyway.

In order to maintain backwards-compatibility, the `compression` feature is now set to enable both `compression-brotli` and `compression-gzip`, which is the current behavior prior to this change.

To that end, if there are any issues with this PR, I'd be glad to resolve them. Thanks! 🎉