### PR TITLE
Add option to ignore content-length with multipart body

### DIFF
--- a/src/filters/multipart.rs
+++ b/src/filters/multipart.rs
@@ -59,15 +59,10 @@ pub fn form() -> FormOptions {
 impl FormOptions {
     /// Set the maximum byte length allowed for this body.
     ///
+    /// `max_length(None)` means that maximum byte length is not checked.
     /// Defaults to 2MB.
-    pub fn max_length(mut self, max: u64) -> Self {
-        self.max_length = Some(max);
-        self
-    }
-
-    /// Set no limit to maximum byte length for the body.
-    pub fn no_max_length(mut self) -> Self {
-        self.max_length = None;
+    pub fn max_length(mut self, max: impl Into<Option<u64>>) -> Self {
+        self.max_length = max.into();
         self
     }
 }

--- a/src/filters/multipart.rs
+++ b/src/filters/multipart.rs
@@ -97,7 +97,7 @@ impl FilterBase for FormOptions {
             Box::pin(
                 super::body::content_length_limit(max_length)
                     .and(filt)
-                    .filter(Internal)
+                    .filter(Internal),
             )
         } else {
             Box::pin(filt.filter(Internal))

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -67,14 +67,15 @@ async fn max_length_is_enforced() {
 
     let req = warp::test::request()
         .method("POST")
+        // Note no content-length header
         .header("transfer-encoding", "chunked")
         .header(
             "content-type",
             format!("multipart/form-data; boundary={}", boundary),
         );
+
     // Intentionally don't add body, as it automatically also adds
     // content-length header
-
     let resp = req.filter(&route).await;
     assert!(resp.is_err());
 }
@@ -83,7 +84,7 @@ async fn max_length_is_enforced() {
 async fn max_length_can_be_disabled() {
     let _ = pretty_env_logger::try_init();
 
-    let route = multipart::form().no_max_length().and_then(|_: multipart::FormData| {
+    let route = multipart::form().max_length(None).and_then(|_: multipart::FormData| {
         async {
             Ok::<(), warp::Rejection>(())
         }
@@ -98,9 +99,9 @@ async fn max_length_can_be_disabled() {
             "content-type",
             format!("multipart/form-data; boundary={}", boundary),
         );
+
     // Intentionally don't add body, as it automatically also adds
     // content-length header
-
     let resp = req.filter(&route).await;
     assert!(resp.is_ok());
 }

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -57,11 +57,8 @@ async fn form_fields() {
 async fn max_length_is_enforced() {
     let _ = pretty_env_logger::try_init();
 
-    let route = multipart::form().and_then(|_: multipart::FormData| {
-        async {
-            Ok::<(), warp::Rejection>(())
-        }
-    });
+    let route = multipart::form()
+        .and_then(|_: multipart::FormData| async { Ok::<(), warp::Rejection>(()) });
 
     let boundary = "--abcdef1234--";
 
@@ -84,11 +81,9 @@ async fn max_length_is_enforced() {
 async fn max_length_can_be_disabled() {
     let _ = pretty_env_logger::try_init();
 
-    let route = multipart::form().max_length(None).and_then(|_: multipart::FormData| {
-        async {
-            Ok::<(), warp::Rejection>(())
-        }
-    });
+    let route = multipart::form()
+        .max_length(None)
+        .and_then(|_: multipart::FormData| async { Ok::<(), warp::Rejection>(()) });
 
     let boundary = "--abcdef1234--";
 

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -52,3 +52,55 @@ async fn form_fields() {
     assert_eq!(&vec[0].0, "foo");
     assert_eq!(&vec[0].1, b"bar");
 }
+
+#[tokio::test]
+async fn max_length_is_enforced() {
+    let _ = pretty_env_logger::try_init();
+
+    let route = multipart::form().and_then(|_: multipart::FormData| {
+        async {
+            Ok::<(), warp::Rejection>(())
+        }
+    });
+
+    let boundary = "--abcdef1234--";
+
+    let req = warp::test::request()
+        .method("POST")
+        .header("transfer-encoding", "chunked")
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={}", boundary),
+        );
+    // Intentionally don't add body, as it automatically also adds
+    // content-length header
+
+    let resp = req.filter(&route).await;
+    assert!(resp.is_err());
+}
+
+#[tokio::test]
+async fn max_length_can_be_disabled() {
+    let _ = pretty_env_logger::try_init();
+
+    let route = multipart::form().no_max_length().and_then(|_: multipart::FormData| {
+        async {
+            Ok::<(), warp::Rejection>(())
+        }
+    });
+
+    let boundary = "--abcdef1234--";
+
+    let req = warp::test::request()
+        .method("POST")
+        .header("transfer-encoding", "chunked")
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={}", boundary),
+        );
+    // Intentionally don't add body, as it automatically also adds
+    // content-length header
+
+    let resp = req.filter(&route).await;
+    assert!(resp.is_ok());
+}


### PR DESCRIPTION
The current implementation of `multipart::form` requires that the `Content-Length` header exists. However, there are valid situations where this is not the case, for example when `Transfer-Encoding` header is present. See e.g. [RFC2616, section 4.4](https://datatracker.ietf.org/doc/html/rfc2616#section-4.4).

This PR adds an option to not check the content length, thus allowing the `multipart::form` filter to be used in cases where `Content-Length` header is not present. The change does not break the existing API.