### PR TITLE
Make file serving helpers public

### DIFF
--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -134,7 +134,7 @@ fn sanitize_path(base: impl AsRef<Path>, tail: &str) -> Result<PathBuf, Rejectio
 
 /// Conditionals that define certain aspects of file serving. These are usually based on the headers of a request, though they can be manually constructed.
 #[allow(missing_docs)] // TODO add docs for these (consult @seanmonstar)
-#[derive(Debug, Default)] // We derive `Default` as well to make constructing this manually easier
+#[derive(Debug, Default)]
 pub struct Conditionals {
     pub if_modified_since: Option<IfModifiedSince>,
     pub if_unmodified_since: Option<IfUnmodifiedSince>,
@@ -261,7 +261,9 @@ impl Reply for File {
     }
 }
 
-/// An internal helper for serving static files. Usually, you'll want to use this with `warp::fs::file`, but if the file's path is based on something extracted with a filter,
+/// An internal helper for serving static files.
+///
+/// Usually, you'll want to use this with `warp::fs::file`, but if the file's path is based on something extracted with a filter,
 /// you'll need to use this manually.
 pub fn file_reply(
     path: ArcPath,

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -133,12 +133,17 @@ fn sanitize_path(base: impl AsRef<Path>, tail: &str) -> Result<PathBuf, Rejectio
 }
 
 /// Conditionals that define certain aspects of file serving. These are usually based on the headers of a request, though they can be manually constructed.
-#[allow(missing_docs)] // TODO add docs for these (consult @seanmonstar)
 #[derive(Debug, Default)]
 pub struct Conditionals {
+    /// Only respond with the file if it has been modified since this date. [See MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since).
     pub if_modified_since: Option<IfModifiedSince>,
+    /// Only respond with the file if it hasn't been modified since this date. [See MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Unmodified-Since).
     pub if_unmodified_since: Option<IfUnmodifiedSince>,
+    /// The `range` conditional should only be used if the document has not been modified since the `Last Modified` header
+    /// or the last ETag creation date. This is typically used to resume downloads after a pause to make sure that the requested
+    /// resource hasn't been changed since the first partial download. [See MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Range).
     pub if_range: Option<IfRange>,
+    /// The part of the file that should be responded with. [See MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range).
     pub range: Option<Range>,
 }
 


### PR DESCRIPTION
This makes some of the contents of [fs.rs](https://github.com/seanmonstar/warp/blob/master/src/filters/fs.rs) public so that users can serve static files at paths based on the request without having to implement file streaming manually.

Fixes #171.