### PR TITLE
Update tokio-rustls to v0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tokio-tungstenite = { version = "0.15", optional = true }
 percent-encoding = "2.1"
 pin-project = "1.0"
 tokio-rustls = { version = "0.23", optional = true }
+rustls-pemfile = "0.2"
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tower-service = "0.3"
 tokio-tungstenite = { version = "0.15", optional = true }
 percent-encoding = "2.1"
 pin-project = "1.0"
-tokio-rustls = { version = "0.22", optional = true }
+tokio-rustls = { version = "0.23", optional = true }
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -28,7 +28,7 @@
 //! #[derive(Debug)]
 //! struct InvalidParameter;
 //!
-//! impl reject::Reject for InvalidParameter {};
+//! impl reject::Reject for InvalidParameter {}
 //!
 //! // Custom rejection handler that maps rejections into responses.
 //! async fn handle_rejection(err: Rejection) -> Result<impl Reply, std::convert::Infallible> {

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -28,7 +28,7 @@
 //! #[derive(Debug)]
 //! struct InvalidParameter;
 //!
-//! impl reject::Reject for InvalidParameter {}
+//! impl reject::Reject for InvalidParameter {};
 //!
 //! // Custom rejection handler that maps rejections into responses.
 //! async fn handle_rejection(err: Rejection) -> Result<impl Reply, std::convert::Infallible> {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -15,8 +15,8 @@ use hyper::server::conn::{AddrIncoming, AddrStream};
 
 use crate::transport::Transport;
 use tokio_rustls::rustls::{
-    AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
-    RootCertStore, ServerConfig, TLSError,
+    server::{AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth},
+    Error as TlsError, RootCertStore, ServerConfig,
 };
 
 /// Represents errors that can occur building the TlsConfig
@@ -32,7 +32,7 @@ pub(crate) enum TlsConfigError {
     /// An error from an empty key
     EmptyKey,
     /// An error from an invalid key
-    InvalidKey(TLSError),
+    InvalidKey(TlsError),
 }
 
 impl fmt::Display for TlsConfigError {
@@ -169,8 +169,8 @@ impl TlsConfigBuilder {
 
     pub(crate) fn build(mut self) -> Result<ServerConfig, TlsConfigError> {
         let mut cert_rdr = BufReader::new(self.cert);
-        let cert = tokio_rustls::rustls::internal::pemfile::certs(&mut cert_rdr)
-            .map_err(|()| TlsConfigError::CertParseError)?;
+        let cert =
+            rustls_pemfile::certs(&mut cert_rdr).map_err(|_e| TlsConfigError::CertParseError)?;
 
         let key = {
             // convert it to Vec<u8> to allow reading it again if key is RSA
@@ -183,18 +183,14 @@ impl TlsConfigBuilder {
                 return Err(TlsConfigError::EmptyKey);
             }
 
-            let mut pkcs8 = tokio_rustls::rustls::internal::pemfile::pkcs8_private_keys(
-                &mut key_vec.as_slice(),
-            )
-            .map_err(|()| TlsConfigError::Pkcs8ParseError)?;
+            let mut pkcs8 = rustls_pemfile::pkcs8_private_keys(&mut key_vec.as_slice())
+                .map_err(|_e| TlsConfigError::Pkcs8ParseError)?;
 
             if !pkcs8.is_empty() {
                 pkcs8.remove(0)
             } else {
-                let mut rsa = tokio_rustls::rustls::internal::pemfile::rsa_private_keys(
-                    &mut key_vec.as_slice(),
-                )
-                .map_err(|()| TlsConfigError::RsaParseError)?;
+                let mut rsa = rustls_pemfile::rsa_private_keys(&mut key_vec.as_slice())
+                    .map_err(|_e| TlsConfigError::RsaParseError)?;
 
                 if !rsa.is_empty() {
                     rsa.remove(0)
@@ -207,13 +203,18 @@ impl TlsConfigBuilder {
         fn read_trust_anchor(
             trust_anchor: Box<dyn Read + Send + Sync>,
         ) -> Result<RootCertStore, TlsConfigError> {
-            let mut reader = BufReader::new(trust_anchor);
+            let trust_anchors = {
+                let mut reader = BufReader::new(trust_anchor);
+                rustls_pemfile::certs(&mut reader).map_err(TlsConfigError::Io)?
+            };
+
             let mut store = RootCertStore::empty();
-            if let Ok((0, _)) | Err(()) = store.add_pem_file(&mut reader) {
-                Err(TlsConfigError::CertParseError)
-            } else {
-                Ok(store)
+            let (added, skipped) = store.add_parsable_certificates(&trust_anchors);
+            if added == 0 {
+                return Err(TlsConfigError::CertParseError);
             }
+
+            Ok(store)
         }
 
         let client_auth = match self.client_auth {


### PR DESCRIPTION
This change bumps the tokio-rustls version to pick up the new version of
rustls.

This helps to avoid duplicate dependencies when using other libraries
that depend on rustls.