### PR TITLE
Expose the custom resolver to the warp interface

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -6,12 +6,16 @@ use std::future::Future;
 use std::net::SocketAddr;
 #[cfg(feature = "tls")]
 use std::path::Path;
+#[cfg(feature = "tls")]
+use std::sync::Arc;
 
 use futures_util::{future, FutureExt, TryFuture, TryStream, TryStreamExt};
 use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::Server as HyperServer;
 use tokio::io::{AsyncRead, AsyncWrite};
+#[cfg(feature = "tls")]
+use tokio_rustls::rustls::server::ResolvesServerCert;
 use tracing::Instrument;
 
 use crate::filter::Filter;
@@ -488,6 +492,13 @@ where
     /// *This function requires the `"tls"` feature.*
     pub fn ocsp_resp(self, resp: impl AsRef<[u8]>) -> Self {
         self.with_tls(|tls| tls.ocsp_resp(resp.as_ref()))
+    }
+
+    /// Specify a custom cert resolver.
+    ///
+    /// *This function requires the `"tls"` feature.*
+    pub fn cert_resolver(self, cert_resolver: Arc<dyn ResolvesServerCert>) -> Self {
+        self.with_tls(|tls| tls.cert_resolver(cert_resolver))
     }
 
     fn with_tls<Func>(self, func: Func) -> Self


### PR DESCRIPTION
This allows users to inject their own CertResolver directly to rustls
for custom cert resolution.

Currently warp provides an interface for using a single certificate for
the duration of the lifecycle of a service.

In some cases, it's useful to be able to inject a custom resolver to
allow more granular use cases. For example, we want to inject a resolver
which periodically reloads the certs from disk to allow live renewals
without interrupting the service.

Exposing the CertResolver configuration allows any custom use case to be
implemented without having to account for every possibility within warp.