### PR TITLE
Add ability to use only one type of compression.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub use self::filter::Filter;
 // This otherwise shows a big dump of re-exports in the doc homepage,
 // with zero context, so just hide it from the docs. Doc examples
 // on each can show that a convenient import exists.
-#[cfg(feature = "compression")]
+#[cfg(any(feature = "compression-brotli", feature = "compression-gzip"))]
 #[doc(hidden)]
 pub use self::filters::compression;
 #[cfg(feature = "multipart")]


### PR DESCRIPTION
Greetings!

I can choose only one type of compression in `Cargo.toml` but can't use it in code. This PR fix it.