### PR TITLE
Update tokio-util to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.7"
 tokio = { version = "1.0", features = ["fs", "sync", "time"] }
 tokio-stream = "0.1.1"
-tokio-util = { version = "0.6", features = ["io"] }
+tokio-util = { version = "0.7", features = ["io"] }
 tracing = { version = "0.1.21", default-features = false, features = ["log", "std"] }
 tower-service = "0.3"
 tokio-tungstenite = { version = "0.15", optional = true }


### PR DESCRIPTION
Hello everybody

warp is curently using tokio-util 0.6 in february tokio-util 0.7 was released.
The changelog can be found here [here](https://github.com/tokio-rs/tokio/blob/master/tokio-util/CHANGELOG.md).

In my opinion this should cause no breakage in warp and would reduce duplicate dependencies in my project.
warp uses hyper which in turn uses h2, h2 already updated to tokio-util 0.7 in this [commit](https://github.com/hyperium/h2/commit/a54d9265b7a6dfc78f67c38db62bfbeae790c1f8).
It would probably make sense to also create a pull request for hyper (which I could do).

I just ran `cargo test` to make sure everything works, as I could not find further instructions for testing.

Help and input would be appreciated!

Kind regards