### PR TITLE
Implement HTTP handling for `TlsServer`

### DIFF
--- a/examples/dual.rs
+++ b/examples/dual.rs
@@ -1,0 +1,26 @@
+#![deny(warnings)]
+
+// Don't copy this `cfg`, it's only needed because this file is within
+// the warp repository.
+// Instead, specify the "tls" feature in your warp dependency declaration.
+#[cfg(feature = "tls")]
+#[tokio::main]
+async fn main() {
+    use warp::Filter;
+
+    // Match any request and return hello world!
+    let routes = warp::any().map(|| "Hello, World!");
+
+    warp::serve(routes)
+        .tls()
+        .http(true)
+        .cert_path("examples/tls/cert.pem")
+        .key_path("examples/tls/key.rsa")
+        .run(([127, 0, 0, 1], 3030))
+        .await;
+}
+
+#[cfg(not(feature = "tls"))]
+fn main() {
+    eprintln!("Requires the `tls` feature.");
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -561,6 +561,13 @@ where
         });
         (addr, fut)
     }
+
+    /// Enable this server to **also** handle HTTP requests.
+    ///
+    /// *This function requires the `"tls"` feature.*
+    pub fn http(self, http: bool) -> Self {
+        self.with_tls(|tls| tls.http(http))
+    }
 }
 
 #[cfg(feature = "tls")]


### PR DESCRIPTION
This allows hosting a HTTP and HTTPS server on the same port. The main use-case is upgrading a connection to HTTPS automatically when going to e.g. "localhost:3030", as browsers connect via HTTP unless explicitly specified.

I implemented in a way to be optional while not disturbing the default path.

This is a first step towards #417. I learned a lot since then :sweat_smile:.