### PR TITLE
Fix test example so it doesn't fail

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -48,7 +48,7 @@
 //!
 //!     // Or simply test if a request matches (doesn't reject).
 //!     assert!(
-//!         !warp::test::request()
+//!         warp::test::request()
 //!             .path("/1/-5")
 //!             .matches(&filter)
 //!             .await


### PR DESCRIPTION
Comment says "Or simply test if a request matches (doesn't reject)"
therefore I would expect for assert to test for success. Also this
example (for sum) will always match. It's confusing the code example
actually tests if it doesn't match.