### PR TITLE
Expose the inner websocket reference to allow code-reuse.

### DIFF
--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -200,6 +200,16 @@ impl WebSocket {
     pub async fn close(mut self) -> Result<(), crate::Error> {
         future::poll_fn(|cx| Pin::new(&mut self).poll_close(cx)).await
     }
+
+    /// Get inner WebSocketStream.
+    pub fn get_inner(&self) -> &WebSocketStream<hyper::upgrade::Upgraded> {
+        &self.inner
+    }
+
+    /// Get mutable inner WebSocketStream.
+    pub fn get_inner_mut(&mut self) -> &mut WebSocketStream<hyper::upgrade::Upgraded> {
+        &mut self.inner
+    }
 }
 
 impl Stream for WebSocket {


### PR DESCRIPTION
Currently, warp::filters::ws::{WebSocket,Message} are two thin layers
built upon crate tokio_tungstenite, user may prefer to use the vanilla
WebSocket interface to share the code between the server and client.

Expose the inner websocket reference with get_{inner, inner_mut}.

Signed-off-by: yuguorui <yuguorui@pku.edu.cn>