### PR TITLE
Expose request query string to trace/log Info struct

### DIFF
--- a/src/filters/log.rs
+++ b/src/filters/log.rs
@@ -124,6 +124,11 @@ impl<'a> Info<'a> {
         self.route.full_path()
     }
 
+    /// View the URI query of the request.
+    pub fn query(&self) -> Option<&str> {
+        self.route.query()
+    }
+
     /// View the `http::Version` of the request.
     pub fn version(&self) -> http::Version {
         self.route.version()

--- a/src/filters/trace.rs
+++ b/src/filters/trace.rs
@@ -172,6 +172,11 @@ impl<'a> Info<'a> {
         self.route.full_path()
     }
 
+    /// View the URI query of the request.
+    pub fn query(&self) -> Option<&str> {
+        self.route.query()
+    }
+
     /// View the `http::Version` of the request.
     pub fn version(&self) -> http::Version {
         self.route.version()


### PR DESCRIPTION
This PR adds methods to `warp::filter::trace::Info` and `warp::filter::log::Info` to view the request's query string.