### PR TITLE
Added feature to access generic file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ listenfd = "0.3"
 default = ["multipart", "websocket"]
 websocket = ["tokio-tungstenite"]
 tls = ["tokio-rustls"]
+# Enable access to private generic file
+generic = []
 
 # Enable compression-related filters
 compression = ["compression-brotli", "compression-gzip"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,10 @@
 mod error;
 mod filter;
 pub mod filters;
+#[cfg(not(feature = "generic"))]
 mod generic;
+#[cfg(feature = "generic")]
+pub mod generic;
 pub mod redirect;
 pub mod reject;
 pub mod reply;


### PR DESCRIPTION
The `generic` file is needed to build functions that involve some filters (ex. `or`) and to allow generic inputs.