### PR TITLE
Make cookie names owned strings instead of static strings

### DIFF
--- a/src/reject.rs
+++ b/src/reject.rs
@@ -104,7 +104,7 @@ pub(crate) fn invalid_header(name: &'static str) -> Rejection {
 
 // 400 Bad Request
 #[inline]
-pub(crate) fn missing_cookie(name: &'static str) -> Rejection {
+pub(crate) fn missing_cookie(name: String) -> Rejection {
     known(MissingCookie { name })
 }
 
@@ -579,13 +579,13 @@ impl StdError for InvalidHeader {}
 /// Missing cookie
 #[derive(Debug)]
 pub struct MissingCookie {
-    name: &'static str,
+    name: String,
 }
 
 impl MissingCookie {
     /// Retrieve the name of the cookie that was missing
     pub fn name(&self) -> &str {
-        self.name
+        self.name.as_str()
     }
 }
 


### PR DESCRIPTION
This PR changes the types used for passing cookie names to the `warp::filters::cookie` filters from `&'static str` to `impl ToString`.
This is a partial fix for #763, however header names cannot use owned strings without some Very Unsafe Code.

Note that this change is completely backwards-compatible - as it uses `impl ToString`, you can still pass in a `&str` and it'll just make an owned string out of it.