### PR TITLE
Add references to `Filter` in documentation

### DIFF
--- a/src/filter/boxed.rs
+++ b/src/filter/boxed.rs
@@ -8,7 +8,7 @@ use futures_util::TryFutureExt;
 use super::{Filter, FilterBase, Internal, Tuple};
 use crate::reject::Rejection;
 
-/// A type representing a boxed `Filter` trait object.
+/// A type representing a boxed [`Filter`](crate::Filter) trait object.
 ///
 /// The filter inside is a dynamic trait object. The purpose of this type is
 /// to ease returning `Filter`s from other functions.

--- a/src/filters/any.rs
+++ b/src/filters/any.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll};
 
 use crate::filter::{Filter, FilterBase, Internal};
 
-/// A filter that matches any route.
+/// A [`Filter`](crate::Filter) that matches any route.
 ///
 /// This can be a useful building block to build new filters from,
 /// since [`Filter`](crate::Filter) is otherwise a sealed trait.

--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -20,7 +20,7 @@ use crate::reply::Reply;
 
 use self::internal::{CorsFilter, IntoOrigin, Seconds};
 
-/// Create a wrapping filter that exposes [CORS][] behavior for a wrapped
+/// Create a wrapping [`Filter`](crate::Filter) that exposes [CORS][] behavior for a wrapped
 /// filter.
 ///
 /// [CORS]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
@@ -56,7 +56,7 @@ pub fn cors() -> Builder {
     }
 }
 
-/// A wrapping filter constructed via `warp::cors()`.
+/// A wrapping [`Filter`](crate::Filter) constructed via `warp::cors()`.
 #[derive(Clone, Debug)]
 pub struct Cors {
     config: Arc<Configured>,

--- a/src/filters/log.rs
+++ b/src/filters/log.rs
@@ -13,7 +13,7 @@ use crate::route::Route;
 
 use self::internal::WithLog;
 
-/// Create a wrapping filter with the specified `name` as the `target`.
+/// Create a wrapping [`Filter`](crate::Filter) with the specified `name` as the `target`.
 ///
 /// This uses the default access logging format, and log records produced
 /// will have their `target` set to `name`.
@@ -50,7 +50,7 @@ pub fn log(name: &'static str) -> Log<impl Fn(Info<'_>) + Copy> {
     Log { func }
 }
 
-/// Create a wrapping filter that receives `warp::log::Info`.
+/// Create a wrapping [`Filter`](crate::Filter) that receives `warp::log::Info`.
 ///
 /// # Example
 ///

--- a/src/filters/multipart.rs
+++ b/src/filters/multipart.rs
@@ -1,6 +1,6 @@
 //! Multipart body filters
 //!
-//! Filters that extract a multipart body for a route.
+//! [`Filter`](crate::Filter)s that extract a multipart body for a route.
 
 use std::error::Error as StdError;
 use std::fmt::{Display, Formatter};
@@ -22,7 +22,7 @@ use crate::reject::{self, Rejection};
 // If not otherwise configured, default to 2MB.
 const DEFAULT_FORM_DATA_MAX_LENGTH: u64 = 1024 * 1024 * 2;
 
-/// A `Filter` to extract a `multipart/form-data` body from a request.
+/// A [`Filter`](crate::Filter) to extract a `multipart/form-data` body from a request.
 ///
 /// Create with the `warp::multipart::form()` function.
 #[derive(Debug, Clone)]
@@ -44,7 +44,7 @@ pub struct Part {
     part: PartInner<'static>,
 }
 
-/// Create a `Filter` to extract a `multipart/form-data` body from a request.
+/// Create a [`Filter`](crate::Filter) to extract a `multipart/form-data` body from a request.
 ///
 /// The extracted `FormData` type is a `Stream` of `Part`s, and each `Part`
 /// in turn is a `Stream` of bytes.

--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -1,6 +1,6 @@
 //! Path Filters
 //!
-//! The filters here work on the "path" of requests.
+//! The [`Filter`](crate::Filter)s here work on the "path" of requests.
 //!
 //! - [`path`](./fn.path.html) matches a specific segment, like `/foo`.
 //! - [`param`](./fn.param.html) tries to parse a segment into a type, like `/:u16`.
@@ -137,7 +137,7 @@ use crate::filter::{filter_fn, one, Filter, FilterBase, Internal, One, Tuple};
 use crate::reject::{self, Rejection};
 use crate::route::{self, Route};
 
-/// Create an exact match path segment `Filter`.
+/// Create an exact match path segment [`Filter`](crate::Filter).
 ///
 /// This will try to match exactly to the current request path segment.
 ///
@@ -189,7 +189,7 @@ where
     */
 }
 
-/// A `Filter` matching an exact path segment.
+/// A [`Filter`](crate::Filter) matching an exact path segment.
 ///
 /// Constructed from `path()` or `path!()`.
 #[allow(missing_debug_implementations)]


### PR DESCRIPTION
A number of functions return structs that (indirectly) implement the `Filter` trait. After not finding an according reference in the documentation for quite a while, I had to look into the code to actually figure out what was going on. In this pull-request I've added some references to the Filter trait in hope it will help point readers into the right direction.