### PR TITLE
Fix docs build

### DIFF
--- a/src/filters/any.rs
+++ b/src/filters/any.rs
@@ -9,7 +9,7 @@ use crate::filter::{Filter, FilterBase, Internal};
 /// A filter that matches any route.
 ///
 /// This can be a useful building block to build new filters from,
-/// since [`Filter`](crate::Filter) is otherwise a sealed trait.
+/// since [`Filter`] is otherwise a sealed trait.
 ///
 /// # Example
 ///

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -37,7 +37,7 @@ use crate::reply::{Reply, Response};
 /// filters, such as after validating in `POST` request, wanting to return a
 /// specific file as the body.
 ///
-/// For serving a directory, see [dir](dir).
+/// For serving a directory, see [dir].
 ///
 /// # Example
 ///

--- a/src/filters/log.rs
+++ b/src/filters/log.rs
@@ -77,7 +77,7 @@ where
     Log { func }
 }
 
-/// Decorates a [`Filter`](crate::Filter) to log requests and responses.
+/// Decorates a [`Filter`] to log requests and responses.
 #[derive(Clone, Copy, Debug)]
 pub struct Log<F> {
     func: F,

--- a/src/filters/reply.rs
+++ b/src/filters/reply.rs
@@ -28,12 +28,12 @@ use self::sealed::{WithDefaultHeader_, WithHeader_, WithHeaders_};
 use crate::filter::{Filter, Map, WrapSealed};
 use crate::reply::Reply;
 
-/// Wrap a [`Filter`](crate::Filter) that adds a header to the reply.
+/// Wrap a [`Filter`] that adds a header to the reply.
 ///
 /// # Note
 ///
 /// This **only** adds a header if the underlying filter is successful, and
-/// returns a [`Reply`](Reply). If the underlying filter was rejected, the
+/// returns a [`Reply`] If the underlying filter was rejected, the
 /// header is not added.
 ///
 /// # Example
@@ -57,12 +57,12 @@ where
     WithHeader { name, value }
 }
 
-/// Wrap a [`Filter`](crate::Filter) that adds multiple headers to the reply.
+/// Wrap a [`Filter`] that adds multiple headers to the reply.
 ///
 /// # Note
 ///
 /// This **only** adds a header if the underlying filter is successful, and
-/// returns a [`Reply`](Reply). If the underlying filter was rejected, the
+/// returns a [`Reply`] If the underlying filter was rejected, the
 /// header is not added.
 ///
 /// # Example
@@ -88,13 +88,13 @@ pub fn headers(headers: HeaderMap) -> WithHeaders {
 
 // pub fn headers?
 
-/// Wrap a [`Filter`](crate::Filter) that adds a header to the reply, if they
+/// Wrap a [`Filter`] that adds a header to the reply, if they
 /// aren't already set.
 ///
 /// # Note
 ///
 /// This **only** adds a header if the underlying filter is successful, and
-/// returns a [`Reply`](Reply). If the underlying filter was rejected, the
+/// returns a [`Reply`] If the underlying filter was rejected, the
 /// header is not added.
 ///
 /// # Example

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -39,6 +39,8 @@
 //! which specifies the expected behavior of Server Sent Events.
 //!
 
+#![allow(rustdoc::invalid_html_tags)]
+
 use serde::Serialize;
 use std::borrow::Cow;
 use std::error::Error as StdError;
@@ -376,7 +378,7 @@ impl KeepAlive {
 
     /// Wrap an event stream with keep-alive functionality.
     ///
-    /// See [`keep_alive`](keep_alive) for more.
+    /// See [`keep_alive`] for more.
     pub fn stream<S>(
         self,
         event_stream: S,

--- a/src/filters/trace.rs
+++ b/src/filters/trace.rs
@@ -123,7 +123,7 @@ pub fn named(name: &'static str) -> Trace<impl Fn(Info<'_>) -> Span + Copy> {
     trace(move |_| tracing::debug_span!("context", "{}", name,))
 }
 
-/// Decorates a [`Filter`](crate::Filter) to create a [`tracing`] [span] for
+/// Decorates a [`Filter`] to create a [`tracing`] [span] for
 /// requests and responses.
 ///
 /// [`tracing`]: https://crates.io/crates/tracing

--- a/src/filters/ws.rs
+++ b/src/filters/ws.rs
@@ -68,7 +68,7 @@ pub fn ws() -> impl Filter<Extract = One<Ws>, Error = Rejection> + Copy {
         )
 }
 
-/// Extracted by the [`ws`](ws) filter, and used to finish an upgrade.
+/// Extracted by the [`ws`] filter, and used to finish an upgrade.
 pub struct Ws {
     config: Option<WebSocketConfig>,
     key: SecWebsocketKey,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //! ## Testing
 //!
 //! Testing your web services easily is extremely important, and warp provides
-//! a [`test`](self::test) module to help send mocked requests through your service.
+//! a [`test`](mod@self::test) module to help send mocked requests through your service.
 //!
 //! [Filter]: trait.Filter.html
 //! [reject]: reject/index.html

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,6 +1,6 @@
 //! Redirect requests to a new location.
 //!
-//! The types in this module are helpers that implement [`Reply`](Reply), and easy
+//! The types in this module are helpers that implement [`Reply`], and easy
 //! to use in order to setup redirects.
 
 use http::{header, StatusCode};

--- a/src/test.rs
+++ b/src/test.rs
@@ -366,7 +366,7 @@ impl RequestBuilder {
 
     /// Returns `Response` provided by applying the `Filter`.
     ///
-    /// This requires that the supplied `Filter` return a [`Reply`](Reply).
+    /// This requires that the supplied `Filter` return a [`Reply`].
     pub async fn reply<F>(self, f: &F) -> Response<Bytes>
     where
         F: Filter + 'static,


### PR DESCRIPTION
This commit fixes the "Build docs" CI step.

Failure example: https://github.com/seanmonstar/warp/actions/runs/5942488679/job/16116874741