### PR TITLE
Fix `cargo minimal-versions check`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ async-compression = { version = "0.3.7", features = ["tokio"], optional = true }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 futures-channel = { version = "0.3.17", features = ["sink"]}
-headers = "0.3"
+headers = "0.3.5"
 http = "0.2"
 hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client"] }
 log = "0.4"
@@ -31,10 +31,10 @@ multer = { version = "2.1.0", optional = true }
 scoped-tls = "1.0"
 serde = "1.0"
 serde_json = "1.0"
-serde_urlencoded = "0.7"
+serde_urlencoded = "0.7.1"
 tokio = { version = "1.0", features = ["fs", "sync", "time"] }
 tokio-stream = "0.1.1"
-tokio-util = { version = "0.7", features = ["io"] }
+tokio-util = { version = "0.7.1", features = ["io"] }
 tracing = { version = "0.1.21", default-features = false, features = ["log", "std"] }
 tower-service = "0.3"
 tokio-tungstenite = { version = "0.20", optional = true }


### PR DESCRIPTION
In a `Cargo.toml`, the dependency versions mean that those versions are the minimum versions required for the project to build.
Sadly, the minimum versions that are given right now will cause compiler errors.

This can be checked through the tool [`cargo-minimal-versions`](https://crates.io/crates/cargo-minimal-versions).

This change modifies the minimal versions so that `cargo minimal-versions check` now succeeds.