### PR TITLE
deps: update tokio-tungstenite, tracing-log and async-compression dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ rustls-pemfile = { version = "2.0", optional = true }
 [dev-dependencies]
 pretty_env_logger = "0.5"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-log = "0.1"
+tracing-log = "0.2"
 serde_derive = "1.0"
 handlebars = "4.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { version = "1.0", features = ["fs", "sync", "time"] }
 tokio-util = { version = "0.7.1", features = ["io"] }
 tracing = { version = "0.1.21", default-features = false, features = ["log", "std"] }
 tower-service = "0.3"
-tokio-tungstenite = { version = "0.20", optional = true }
+tokio-tungstenite = { version = "0.21", optional = true }
 percent-encoding = "2.1"
 pin-project = "1.0"
 tokio-rustls = { version = "0.25", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-async-compression = { version = "0.3.7", features = ["tokio"], optional = true }
+async-compression = { version = "0.4.5", features = ["tokio"], optional = true }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 futures-channel = { version = "0.3.17", features = ["sink"]}

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -826,7 +826,7 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct X(u32);
+    struct X(#[allow(unused)] u32);
     impl Reject for X {}
 
     fn combine_n<F, R>(n: u32, new_reject: F) -> Rejection


### PR DESCRIPTION
Updates dependencies: `tokio-tungstenite` 0.21, `tracing-log` 0.2 and `async-compression` 0.4.5.