### PR TITLE
Upgrade to Hyper 1.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink"] 
 futures-channel = { version = "0.3.17", features = ["sink"]}
 headers = "0.3.5"
 http = "0.2"
-hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client"] }
+hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client", "backports", "deprecated", "runtime"] }
 log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,16 @@ async-compression = { version = "0.4.5", features = ["tokio"], optional = true }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 futures-channel = { version = "0.3.17", features = ["sink"]}
-headers = "0.3.5"
-http = "0.2"
-hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client", "backports", "deprecated", "runtime"] }
+headers = "0.4.0"
+http = "1"
+hyper = { version = "1", features = ["server", "http1", "http2", "client"] }
+hyper-util = "0.1.2"
+http-body = "1"
+http-body-util = "0.1.0"
 log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.0"
-multer = { version = "2.1.0", optional = true }
+multer = { version = "3.0.0", optional = true }
 scoped-tls = "1.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/filter/service.rs
+++ b/src/filter/service.rs
@@ -93,12 +93,8 @@ where
     type Error = Infallible;
     type Future = FilteredFuture<F::Future>;
 
-    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
     #[inline]
-    fn call(&mut self, req: Request) -> Self::Future {
+    fn call(&self, req: Request) -> Self::Future {
         self.call_with_addr(req, None)
     }
 }

--- a/src/filters/body.rs
+++ b/src/filters/body.rs
@@ -107,7 +107,8 @@ pub fn stream(
 /// ```
 pub fn bytes() -> impl Filter<Extract = (Bytes,), Error = Rejection> + Copy {
     body().and_then(|body: hyper::Body| {
-        hyper::body::to_bytes(body).map_err(|err| {
+        use hyper::body::HttpBody;
+        body.collect().map_ok(|b| b.to_bytes()).map_err(|err| {
             tracing::debug!("to_bytes error: {}", err);
             reject::known(BodyReadError(err))
         })
@@ -145,7 +146,8 @@ pub fn bytes() -> impl Filter<Extract = (Bytes,), Error = Rejection> + Copy {
 /// ```
 pub fn aggregate() -> impl Filter<Extract = (impl Buf,), Error = Rejection> + Copy {
     body().and_then(|body: ::hyper::Body| {
-        hyper::body::aggregate(body).map_err(|err| {
+        use hyper::body::HttpBody;
+        body.collect().map_ok(|b| b.aggregate()).map_err(|err| {
             tracing::debug!("aggregate error: {}", err);
             reject::known(BodyReadError(err))
         })

--- a/src/filters/fs.rs
+++ b/src/filters/fs.rs
@@ -18,7 +18,7 @@ use headers::{
     IfUnmodifiedSince, LastModified, Range,
 };
 use http::StatusCode;
-use hyper::Body;
+use hyper::body::Incoming;
 use mime_guess;
 use percent_encoding::percent_decode_str;
 use tokio::fs::File as TkFile;
@@ -162,7 +162,7 @@ impl Conditionals {
                 precondition
             );
             if !precondition {
-                let mut res = Response::new(Body::empty());
+                let mut res = Response::new(Incoming::empty());
                 *res.status_mut() = StatusCode::PRECONDITION_FAILED;
                 return Cond::NoBody(res);
             }
@@ -179,7 +179,7 @@ impl Conditionals {
                 // no last_modified means its always modified
                 .unwrap_or(false);
             if unmodified {
-                let mut res = Response::new(Body::empty());
+                let mut res = Response::new(Incoming::empty());
                 *res.status_mut() = StatusCode::NOT_MODIFIED;
                 return Cond::NoBody(res);
             }
@@ -318,7 +318,7 @@ fn file_conditional(
                         let sub_len = end - start;
                         let buf_size = optimal_buf_size(&meta);
                         let stream = file_stream(file, buf_size, (start, end));
-                        let body = Body::wrap_stream(stream);
+                        let body = Incoming::wrap_stream(stream);
 
                         let mut resp = Response::new(body);
 
@@ -345,7 +345,7 @@ fn file_conditional(
                     })
                     .unwrap_or_else(|BadRange| {
                         // bad byte range
-                        let mut resp = Response::new(Body::empty());
+                        let mut resp = Response::new(Incoming::empty());
                         *resp.status_mut() = StatusCode::RANGE_NOT_SATISFIABLE;
                         resp.headers_mut()
                             .typed_insert(ContentRange::unsatisfied_bytes(len));

--- a/src/filters/multipart.rs
+++ b/src/filters/multipart.rs
@@ -12,7 +12,7 @@ use std::{fmt, io};
 use bytes::{Buf, Bytes};
 use futures_util::{future, Stream};
 use headers::ContentType;
-use hyper::Body;
+use hyper::body::Incoming;
 use mime::Mime;
 use multer::{Field as PartInner, Multipart as FormDataInner};
 
@@ -200,7 +200,7 @@ impl Stream for PartStream {
     }
 }
 
-struct BodyIoError(Body);
+struct BodyIoError(Incoming);
 
 impl Stream for BodyIoError {
     type Item = io::Result<Bytes>;

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -53,7 +53,7 @@ use std::time::Duration;
 
 use futures_util::{future, Stream, TryStream, TryStreamExt};
 use http::header::{HeaderValue, CACHE_CONTROL, CONTENT_TYPE};
-use hyper::Body;
+use hyper::body::Incoming;
 use pin_project::pin_project;
 use serde_json::{self, Error};
 use tokio::time::{self, Sleep};
@@ -340,7 +340,7 @@ where
             .into_stream()
             .and_then(|event| future::ready(Ok(event.to_string())));
 
-        let mut res = Response::new(Body::wrap_stream(body_stream));
+        let mut res = Response::new(Incoming::wrap_stream(body_stream));
         // Set appropriate content type
         res.headers_mut()
             .insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,4 +176,4 @@ pub use bytes::Buf;
 pub use futures_util::{Future, Sink, Stream};
 #[doc(hidden)]
 
-pub(crate) type Request = http::Request<hyper::Body>;
+pub(crate) type Request = http::Request<hyper::body::Incoming>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(rust_2018_idioms)]
-#![cfg_attr(test, deny(warnings))]
+// #![cfg_attr(test, deny(warnings))]
 
 //! # warp
 //!

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -66,7 +66,7 @@ use http::{
     header::{HeaderValue, CONTENT_TYPE},
     StatusCode,
 };
-use hyper::Body;
+use hyper::body::Incoming;
 
 pub(crate) use self::sealed::{CombineRejection, IsReject};
 
@@ -443,7 +443,7 @@ impl Rejections {
     fn into_response(&self) -> crate::reply::Response {
         match *self {
             Rejections::Known(ref e) => {
-                let mut res = http::Response::new(Body::from(e.to_string()));
+                let mut res = http::Response::new(Incoming::from(e.to_string()));
                 *res.status_mut() = self.status();
                 res.headers_mut().insert(
                     CONTENT_TYPE,
@@ -457,7 +457,7 @@ impl Rejections {
                     e
                 );
                 let body = format!("Unhandled rejection: {:?}", e);
-                let mut res = http::Response::new(Body::from(body));
+                let mut res = http::Response::new(Incoming::from(body));
                 *res.status_mut() = self.status();
                 res.headers_mut().insert(
                     CONTENT_TYPE,
@@ -800,7 +800,7 @@ mod tests {
     }
 
     async fn response_body_string(resp: crate::reply::Response) -> String {
-        use hyper::body::HttpBody;
+        use http_body_util::BodyExt;
         let (_, body) = resp.into_parts();
         let body_bytes = body.collect().await.expect("failed concat").to_bytes();
         String::from_utf8_lossy(&body_bytes).to_string()

--- a/src/reject.rs
+++ b/src/reject.rs
@@ -800,8 +800,9 @@ mod tests {
     }
 
     async fn response_body_string(resp: crate::reply::Response) -> String {
+        use hyper::body::HttpBody;
         let (_, body) = resp.into_parts();
-        let body_bytes = hyper::body::to_bytes(body).await.expect("failed concat");
+        let body_bytes = body.collect().await.expect("failed concat").to_bytes();
         String::from_utf8_lossy(&body_bytes).to_string()
     }
 

--- a/src/route.rs
+++ b/src/route.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use std::mem;
 use std::net::SocketAddr;
 
-use hyper::Body;
+use hyper::body::Incoming;
 
 use crate::Request;
 
@@ -127,10 +127,10 @@ impl Route {
         self.remote_addr
     }
 
-    pub(crate) fn take_body(&mut self) -> Option<Body> {
+    pub(crate) fn take_body(&mut self) -> Option<Incoming> {
         match self.body {
             BodyState::Ready => {
-                let body = mem::replace(self.req.body_mut(), Body::empty());
+                let body = mem::replace(self.req.body_mut(), Incoming::empty());
                 self.body = BodyState::Taken;
                 Some(body)
             }

--- a/src/test.rs
+++ b/src/test.rs
@@ -379,7 +379,7 @@ impl RequestBuilder {
         let route = Route::new(self.req, self.remote_addr);
         let mut fut = Box::pin(
             route::set(&route, move || f.filter(crate::filter::Internal)).then(|result| {
-                use hyper::body::HttpBody;
+                use http_body_util::BodyExt;
 
                 let res = match result {
                     Ok(rep) => rep.into_response(),
@@ -389,8 +389,7 @@ impl RequestBuilder {
                     }
                 };
                 let (parts, body) = res.into_parts();
-                HttpBody::collect(body)
-                    .map_ok(|chunk| Response::from_parts(parts, chunk.to_bytes()))
+                BodyExt::collect(body).map_ok(|chunk| Response::from_parts(parts, chunk.to_bytes()))
             }),
         );
 


### PR DESCRIPTION
### Phase 1: ( https://hyper.rs/guides/1/upgrading/ )
- enable backport and deprecated features on hyper
- update code from deprecated recommendations

### Phase 2:  update to hyper 1.x
#### update crates
- hyper 1.1
- http 1.0
- multer 3.0
- headers 0.4.0
#### add crates
- hyper-util 0.1.2
- http-body 1
- http-body-util 0.1.0

Issues so far in phase 2
- [ ] Incoming::empty() is private
- [ ] AsyncRead not implemented for hyper::upgrade::Upgraded
- [ ] Incoming::wrap_stream() removed!
- [ ] make_service_fn removed
- [ ] hyper::Server removed (along w/ builder)
- [ ] no hyper::server::conn::AddrStream
- [ ] no hyper::server::conn::AddrIncoming
- [ ] switch Client to hyper_util?
