### PR TITLE
chore: bump tokio-tungstenite to 0.26.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { version = "1.0", features = ["fs", "sync", "time"] }
 tokio-util = { version = "0.7.1", features = ["io"] }
 tracing = { version = "0.1.21", default-features = false, features = ["log", "std"] }
 tower-service = "0.3"
-tokio-tungstenite = { version = "0.21", optional = true }
+tokio-tungstenite = { version = "0.26.1", optional = true }
 percent-encoding = "2.1"
 pin-project = "1.0"
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"], optional = true }

--- a/src/test.rs
+++ b/src/test.rs
@@ -572,7 +572,7 @@ impl WsBuilder {
 impl WsClient {
     /// Send a "text" websocket message to the server.
     pub async fn send_text(&mut self, text: impl Into<String>) {
-        self.send(crate::ws::Message::text(text)).await;
+        self.send(crate::ws::Message::text(text.into())).await;
     }
 
     /// Send a websocket message to the server.


### PR DESCRIPTION
Not entirely sure what to do with `Bytes`/`Utf8Bytes`. Re-export, warp (similarly how `Message` is handled)... ?