### PR TITLE
Move to minimum working hyper util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ headers = "0.4"
 http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["server", "http1", "http2"] }
-hyper-util = { version = "0.1", features = ["server", "server-graceful", "server-auto", "http1", "http2", "service", "tokio"], optional = true }
+hyper-util = { version = "0.1.12", features = ["server", "server-graceful", "server-auto", "http1", "http2", "service", "tokio"], optional = true }
 log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.0"


### PR DESCRIPTION
If hyper-util 0.1.11 is in the build tree then you get the following error:

```
error[E0599]: no method named `watcher` found for struct `GracefulShutdown` in the current scope
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/warp-0.4.1/src/server.rs:368:45
    |
368 |                 let watcher = graceful_util.watcher();
    |                                             ^^^^^^^
    |
help: there is a method `watch` with a similar name, but with different arguments
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hyper-util-0.1.11/src/server/graceful.rs:32:5
    |
32  |     pub fn watch<C: GracefulConnection>(&self, conn: C) -> impl Future<Output = C::Output> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `warp` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

This goes away with hyper-util 0.1.12 so I've set that in the manifest so if a suer is on an earlier version it'll upgrade (and not impact anyone on a newer version)