### PR TITLE
Bump `http-body-util` min version to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink"] 
 futures-channel = { version = "0.3.17", features = ["sink"]}
 headers = "0.4"
 http = "1"
-http-body-util = "0.1"
+http-body-util = "0.1.2"
 hyper = { version = "1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1.12", features = ["server", "server-graceful", "server-auto", "http1", "http2", "service", "tokio"], optional = true }
 log = "0.4"


### PR DESCRIPTION
Similar to #1128, but [for `http-body-util`](https://github.com/seanmonstar/warp/pull/1128#issuecomment-3164550418).

```rust
 error[E0432]: unresolved import `http_body_util::BodyDataStream`
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/warp-0.4.0/src/filters/body.rs:14:5
   |
14 | use http_body_util::BodyDataStream;
   |     ^^^^^^^^^^^^^^^^--------------
   |     |               |
   |     |               help: a similar name exists in the module: `BodyStream`
   |     no `BodyDataStream` in the root
```