### PR TITLE
Spawn tasks with current tracing subscriber

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -284,6 +284,8 @@ mod accept {
 }
 
 mod run {
+    use tracing::instrument::WithSubscriber;
+
     pub trait Run {
         #[allow(async_fn_in_trait)]
         async fn run<F, A>(server: super::Server<F, A, Self>)
@@ -318,25 +320,28 @@ mod run {
                 };
                 let svc = crate::service(server.filter.clone());
                 let svc = hyper_util::service::TowerToHyperService::new(svc);
-                tokio::spawn(async move {
-                    let io = match accepting.await {
-                        Ok(io) => io,
-                        Err(err) => {
-                            tracing::debug!("server accept error: {:?}", err);
-                            return;
+                tokio::spawn(
+                    async move {
+                        let io = match accepting.await {
+                            Ok(io) => io,
+                            Err(err) => {
+                                tracing::debug!("server accept error: {:?}", err);
+                                return;
+                            }
+                        };
+                        if let Err(err) = hyper_util::server::conn::auto::Builder::new(
+                            hyper_util::rt::TokioExecutor::new(),
+                        )
+                        .http1()
+                        .pipeline_flush(pipeline)
+                        .serve_connection_with_upgrades(io, svc)
+                        .await
+                        {
+                            tracing::error!("server connection error: {:?}", err)
                         }
-                    };
-                    if let Err(err) = hyper_util::server::conn::auto::Builder::new(
-                        hyper_util::rt::TokioExecutor::new(),
-                    )
-                    .http1()
-                    .pipeline_flush(pipeline)
-                    .serve_connection_with_upgrades(io, svc)
-                    .await
-                    {
-                        tracing::error!("server connection error: {:?}", err)
                     }
-                });
+                    .with_current_subscriber(),
+                );
             }
         }
     }
@@ -377,24 +382,27 @@ mod run {
                 let svc = crate::service(server.filter.clone());
                 let svc = hyper_util::service::TowerToHyperService::new(svc);
                 let watcher = graceful_util.watcher();
-                tokio::spawn(async move {
-                    let io = match accepting.await {
-                        Ok(io) => io,
-                        Err(err) => {
-                            tracing::debug!("server accepting error: {:?}", err);
-                            return;
+                tokio::spawn(
+                    async move {
+                        let io = match accepting.await {
+                            Ok(io) => io,
+                            Err(err) => {
+                                tracing::debug!("server accepting error: {:?}", err);
+                                return;
+                            }
+                        };
+                        let mut hyper = hyper_util::server::conn::auto::Builder::new(
+                            hyper_util::rt::TokioExecutor::new(),
+                        );
+                        hyper.http1().pipeline_flush(pipeline);
+                        let conn = hyper.serve_connection_with_upgrades(io, svc);
+                        let conn = watcher.watch(conn);
+                        if let Err(err) = conn.await {
+                            tracing::error!("server connection error: {:?}", err)
                         }
-                    };
-                    let mut hyper = hyper_util::server::conn::auto::Builder::new(
-                        hyper_util::rt::TokioExecutor::new(),
-                    );
-                    hyper.http1().pipeline_flush(pipeline);
-                    let conn = hyper.serve_connection_with_upgrades(io, svc);
-                    let conn = watcher.watch(conn);
-                    if let Err(err) = conn.await {
-                        tracing::error!("server connection error: {:?}", err)
                     }
-                });
+                    .with_current_subscriber(),
+                );
             }
 
             drop(server.acceptor); // close listener


### PR DESCRIPTION
Before this PR, tracing logs work with the default subscriber (which is the usual case), but when one sets a custom tracing subscriber, it isn't passed across `tokio::spawn` boundaries.

In this PR I'm adding the method `.with_current_subscriber()` to server tasks. This allows the logging subscriber to be carried into the spawned tasks.

```rust
// Before: subscriber context lost
tokio::spawn(async { ... });

// After: subscriber context preserved  
tokio::spawn(async { ... }.with_current_subscriber());
```

My use case is capturing logging for integration tests, for which I need to set a custom tracing subscriber. I think this PR shouldn't change anything in the common case of a global subscriber.