### PR TITLE
docs: replace doc_auto_cfg config with doc_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(rust_2018_idioms)]
 #![cfg_attr(test, deny(warnings))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! # warp
 //!


### PR DESCRIPTION
`doc_auto_cfg` was merged into `doc_cfg` in https://github.com/rust-lang/rust/pull/138907.