### PR TITLE
Create Body from `&'static [u8]`.

### DIFF
--- a/src/bodyt.rs
+++ b/src/bodyt.rs
@@ -92,6 +92,12 @@ impl From<String> for Body {
     }
 }
 
+impl From<&'static [u8]> for Body {
+    fn from(v: &'static [u8]) -> Self {
+        Bytes::from(v).into()
+    }
+}
+
 impl From<Vec<u8>> for Body {
     fn from(v: Vec<u8>) -> Self {
         Bytes::from(v).into()


### PR DESCRIPTION
In warp 0.3 there was a convenient converter from a static byte slice to a response body, so this fixes a minor regression.

Since warp 0.4 has such converters for `String`, `&str`, and `Vec<u8>`, I think it would be reasonable to have such a converter for `&[u8]` as well.

## Alternatives

It would be possible to add a generic `impl<T: Into<Bytes>> From<T> for Body` instead.  But perhaps that would have confusing side effects?

Of course, the using create could also make the conversion though `Bytes`, but since `warp` does not re-export it the calling crate would then need a direct dependency on `bytes`.