### PR TITLE
Provides warp::reply::stream

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -127,6 +127,29 @@ impl Reply for Json {
     }
 }
 
+/// Converts a [`Stream`](futures_util::Stream) of data chunks into a reply.
+///
+/// # Example
+///
+/// ```
+/// use warp::Filter;
+/// use futures_util::stream;
+/// use bytes::Bytes;
+///
+/// let route = warp::any().map(|| {
+///     let chunks = vec![Ok::<_, std::io::Error>(Bytes::from("hello"))];
+///     warp::reply::stream(stream::iter(chunks))
+/// });
+/// ```
+pub fn stream<S, B, E>(stream: S) -> impl Reply
+where
+    S: futures_util::Stream<Item = Result<B, E>> + Send + Sync + 'static,
+    B: Into<bytes::Bytes>,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + Send + 'static,
+{
+    Response::new(Body::wrap_stream(stream))
+}
+
 /// Reply with a body and `content-type` set to `text/html; charset=utf-8`.
 ///
 /// # Example


### PR DESCRIPTION
Before 0.4 a stream could by sent as body via
Body::wrap_stream. This has been made
private to not expose any internal workings.

With this change, replying with a stream is
possible again without exposing any
internals.

Fixes: #1136 