### PR TITLE
feat: reimplement `warp::addr::remote()` filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,10 @@ name = "websockets_chat"
 required-features = ["websocket", "server"]
 
 [[test]]
+name = "addr"
+required-features = ["test"]
+
+[[test]]
 name = "body"
 required-features = ["test"]
 

--- a/src/filters/addr.rs
+++ b/src/filters/addr.rs
@@ -3,6 +3,8 @@
 use std::convert::Infallible;
 use std::net::SocketAddr;
 
+use futures_util::future;
+
 use crate::filter::{filter_fn_one, Filter};
 
 /// Creates a `Filter` to get the remote address of the connection.
@@ -22,7 +24,5 @@ use crate::filter::{filter_fn_one, Filter};
 ///     });
 /// ```
 pub fn remote() -> impl Filter<Extract = (Option<SocketAddr>,), Error = Infallible> + Copy {
-    // TODO: should be replaced with just simple extensions insert by a
-    // make service and then gotten again here.
-    //filter_fn_one(|route| futures_util::future::ok(route.remote_addr()))
+    filter_fn_one(|route| future::ok(route.extensions().get::<SocketAddr>().cloned()))
 }

--- a/src/filters/addr.rs
+++ b/src/filters/addr.rs
@@ -24,5 +24,15 @@ use crate::filter::{filter_fn_one, Filter};
 ///     });
 /// ```
 pub fn remote() -> impl Filter<Extract = (Option<SocketAddr>,), Error = Infallible> + Copy {
-    filter_fn_one(|route| future::ok(route.extensions().get::<SocketAddr>().cloned()))
+    filter_fn_one(|route| {
+        future::ok(
+            route
+                .extensions()
+                .get::<RemoteAddr>()
+                .map(|RemoteAddr(addr)| *addr),
+        )
+    })
 }
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RemoteAddr(pub(crate) SocketAddr);

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -3,7 +3,7 @@
 //! This module mostly serves as documentation to group together the list of
 //! built-in filters. Most of these are available at more convenient paths.
 
-//pub mod addr;
+pub mod addr;
 pub mod any;
 pub mod body;
 #[cfg(any(feature = "compression-brotli", feature = "compression-gzip"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub use self::filters::multipart;
 pub use self::filters::ws;
 #[doc(hidden)]
 pub use self::filters::{
-    //addr,
+    addr,
     // any() function
     any::any,
     body,

--- a/src/server.rs
+++ b/src/server.rs
@@ -235,10 +235,14 @@ where
 }
 
 mod accept {
+    use std::net::SocketAddr;
+
     pub trait Accept {
         type IO: hyper::rt::Read + hyper::rt::Write + Send + Unpin + 'static;
         type AcceptError: std::fmt::Debug;
-        type Accepting: super::Future<Output = Result<Self::IO, Self::AcceptError>> + Send + 'static;
+        type Accepting: super::Future<Output = Result<(Self::IO, Option<SocketAddr>), Self::AcceptError>>
+            + Send
+            + 'static;
         #[allow(async_fn_in_trait)]
         async fn accept(&mut self) -> Result<Self::Accepting, std::io::Error>;
     }
@@ -249,10 +253,14 @@ mod accept {
     impl Accept for tokio::net::TcpListener {
         type IO = hyper_util::rt::TokioIo<tokio::net::TcpStream>;
         type AcceptError = std::convert::Infallible;
-        type Accepting = std::future::Ready<Result<Self::IO, Self::AcceptError>>;
+        type Accepting =
+            std::future::Ready<Result<(Self::IO, Option<SocketAddr>), Self::AcceptError>>;
         async fn accept(&mut self) -> Result<Self::Accepting, std::io::Error> {
-            let (io, _addr) = <tokio::net::TcpListener>::accept(self).await?;
-            Ok(std::future::ready(Ok(hyper_util::rt::TokioIo::new(io))))
+            let (io, addr) = <tokio::net::TcpListener>::accept(self).await?;
+            Ok(std::future::ready(Ok((
+                hyper_util::rt::TokioIo::new(io),
+                Some(addr),
+            ))))
         }
     }
 
@@ -260,10 +268,14 @@ mod accept {
     impl Accept for tokio::net::UnixListener {
         type IO = hyper_util::rt::TokioIo<tokio::net::UnixStream>;
         type AcceptError = std::convert::Infallible;
-        type Accepting = std::future::Ready<Result<Self::IO, Self::AcceptError>>;
+        type Accepting =
+            std::future::Ready<Result<(Self::IO, Option<SocketAddr>), Self::AcceptError>>;
         async fn accept(&mut self) -> Result<Self::Accepting, std::io::Error> {
             let (io, _addr) = <tokio::net::UnixListener>::accept(self).await?;
-            Ok(std::future::ready(Ok(hyper_util::rt::TokioIo::new(io))))
+            Ok(std::future::ready(Ok((
+                hyper_util::rt::TokioIo::new(io),
+                None,
+            ))))
         }
     }
 
@@ -275,10 +287,52 @@ mod accept {
     impl<A: Accept> Accept for Tls<A> {
         type IO = hyper_util::rt::TokioIo<tokio::net::TcpStream>;
         type AcceptError = std::convert::Infallible;
-        type Accepting = std::future::Ready<Result<Self::IO, Self::AcceptError>>;
+        type Accepting =
+            std::future::Ready<Result<(Self::IO, Option<SocketAddr>), Self::AcceptError>>;
         async fn accept(&mut self) -> Result<Self::Accepting, std::io::Error> {
-            let (io, _addr) = self.0.accept().await?;
-            Ok(std::future::ready(Ok(hyper_util::rt::TokioIo::new(io))))
+            let (io, addr) = self.0.accept().await?;
+            Ok(std::future::ready(Ok((
+                hyper_util::rt::TokioIo::new(io),
+                addr,
+            ))))
+        }
+    }
+}
+
+mod middleware {
+    use std::net::SocketAddr;
+    use std::task::{Context, Poll};
+    use tower_service::Service;
+
+    #[derive(Clone, Debug)]
+    pub(super) struct RemoteAddrService<S> {
+        inner: S,
+        remote_addr: Option<SocketAddr>,
+    }
+
+    impl<S> RemoteAddrService<S> {
+        pub(super) fn new(inner: S, remote_addr: Option<SocketAddr>) -> Self {
+            Self { inner, remote_addr }
+        }
+    }
+
+    impl<S, B> Service<http::Request<B>> for RemoteAddrService<S>
+    where
+        S: Service<http::Request<B>>,
+    {
+        type Response = S::Response;
+        type Error = S::Error;
+        type Future = S::Future;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+            if let Some(addr) = self.remote_addr {
+                req.extensions_mut().insert(addr);
+            }
+            self.inner.call(req)
         }
     }
 }
@@ -317,15 +371,16 @@ mod run {
                     }
                 };
                 let svc = crate::service(server.filter.clone());
-                let svc = hyper_util::service::TowerToHyperService::new(svc);
                 tokio::spawn(async move {
-                    let io = match accepting.await {
-                        Ok(io) => io,
+                    let (io, remote_addr) = match accepting.await {
+                        Ok(pair) => pair,
                         Err(err) => {
                             tracing::debug!("server accept error: {:?}", err);
                             return;
                         }
                     };
+                    let svc = super::middleware::RemoteAddrService::new(svc, remote_addr);
+                    let svc = hyper_util::service::TowerToHyperService::new(svc);
                     if let Err(err) = hyper_util::server::conn::auto::Builder::new(
                         hyper_util::rt::TokioExecutor::new(),
                     )
@@ -375,16 +430,17 @@ mod run {
                     }
                 };
                 let svc = crate::service(server.filter.clone());
-                let svc = hyper_util::service::TowerToHyperService::new(svc);
                 let watcher = graceful_util.watcher();
                 tokio::spawn(async move {
-                    let io = match accepting.await {
-                        Ok(io) => io,
+                    let (io, remote_addr) = match accepting.await {
+                        Ok(pair) => pair,
                         Err(err) => {
                             tracing::debug!("server accepting error: {:?}", err);
                             return;
                         }
                     };
+                    let svc = super::middleware::RemoteAddrService::new(svc, remote_addr);
+                    let svc = hyper_util::service::TowerToHyperService::new(svc);
                     let mut hyper = hyper_util::server::conn::auto::Builder::new(
                         hyper_util::rt::TokioExecutor::new(),
                     );

--- a/src/server.rs
+++ b/src/server.rs
@@ -304,6 +304,8 @@ mod middleware {
     use std::task::{Context, Poll};
     use tower_service::Service;
 
+    use crate::filters::addr::RemoteAddr;
+
     #[derive(Clone, Debug)]
     pub(super) struct RemoteAddrService<S> {
         inner: S,
@@ -330,7 +332,7 @@ mod middleware {
 
         fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
             if let Some(addr) = self.remote_addr {
-                req.extensions_mut().insert(addr);
+                req.extensions_mut().insert(RemoteAddr(addr));
             }
             self.inner.call(req)
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -109,6 +109,7 @@ use serde::Serialize;
 use tokio::sync::oneshot;
 
 use crate::filter::Filter;
+use crate::filters::addr::RemoteAddr;
 #[cfg(feature = "websocket")]
 use crate::filters::ws::Message;
 use crate::reject::IsReject;
@@ -247,7 +248,7 @@ impl RequestBuilder {
     ///     .remote_addr(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080));
     /// ```
     pub fn remote_addr(mut self, addr: SocketAddr) -> Self {
-        self.req.extensions_mut().insert(addr);
+        self.req.extensions_mut().insert(RemoteAddr(addr));
         self
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -123,7 +123,6 @@ use self::inner::OneOrTuple;
 /// Starts a new test `RequestBuilder`.
 pub fn request() -> RequestBuilder {
     RequestBuilder {
-        remote_addr: None,
         req: Request::default(),
     }
 }
@@ -140,7 +139,6 @@ pub fn ws() -> WsBuilder {
 #[must_use = "RequestBuilder does nothing on its own"]
 #[derive(Debug)]
 pub struct RequestBuilder {
-    remote_addr: Option<SocketAddr>,
     req: Request,
 }
 
@@ -249,7 +247,7 @@ impl RequestBuilder {
     ///     .remote_addr(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080));
     /// ```
     pub fn remote_addr(mut self, addr: SocketAddr) -> Self {
-        self.remote_addr = Some(addr);
+        self.req.extensions_mut().insert(addr);
         self
     }
 

--- a/tests/addr.rs
+++ b/tests/addr.rs
@@ -1,6 +1,5 @@
 #![deny(warnings)]
 
-/*
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 #[tokio::test]
@@ -23,4 +22,3 @@ async fn remote_addr_present() {
         Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 5678))
     )
 }
-*/


### PR DESCRIPTION
Reimplements `warp::addr::remote()` filter and enables the `warp::addr` module, which was disabled during the upgrade to hyper v1.

Let me know if there's something missing, or you prefer a different implementation.

Closes https://github.com/seanmonstar/warp/issues/1127.