### PR TITLE
feat: reexpose `Info::remote_addr()` in log filter

### DIFF
--- a/src/filters/log.rs
+++ b/src/filters/log.rs
@@ -1,6 +1,7 @@
 //! Logger Filters
 
 use std::fmt;
+use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
 use http::{header, StatusCode};
@@ -35,7 +36,8 @@ pub fn log(name: &'static str) -> Log<impl Fn(Info<'_>) + Copy> {
         // - response content length?
         log::info!(
             target: name,
-            "\"{} {} {:?}\" {} \"{}\" \"{}\" {:?}",
+            "{} \"{} {} {:?}\" {} \"{}\" \"{}\" {:?}",
+            OptFmt(info.route.remote_addr()),
             info.method(),
             info.path(),
             info.route.version(),
@@ -107,6 +109,11 @@ where
 }
 
 impl<'a> Info<'a> {
+    /// View the remote `SocketAddr` of the request.
+    pub fn remote_addr(&self) -> Option<SocketAddr> {
+        self.route.remote_addr()
+    }
+
     /// View the `http::Method` of the request.
     pub fn method(&self) -> &http::Method {
         self.route.method()

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,7 +1,9 @@
 use scoped_tls::scoped_thread_local;
 use std::cell::RefCell;
 use std::mem;
+use std::net::SocketAddr;
 
+use crate::addr::RemoteAddr;
 use crate::{bodyt::Body, Request};
 
 scoped_thread_local!(static ROUTE: RefCell<Route>);
@@ -116,6 +118,13 @@ impl Route {
             index,
         );
         self.segments_index = index;
+    }
+
+    pub(crate) fn remote_addr(&self) -> Option<SocketAddr> {
+        self.req
+            .extensions()
+            .get::<RemoteAddr>()
+            .map(|RemoteAddr(addr)| *addr)
     }
 
     pub(crate) fn take_body(&mut self) -> Option<Body> {


### PR DESCRIPTION
Reexposes `Info::remote_addr()` in the default log filter and for custom log filter usage. These were previously disabled during the upgrade to hyper v1.

Let me know if there's something missing.

Closes https://github.com/seanmonstar/warp/issues/1150.