### PR TITLE
Remove `Sync` requirement on `Body` and `Stream` objects

### DIFF
--- a/src/bodyt.rs
+++ b/src/bodyt.rs
@@ -5,10 +5,10 @@ use bytes::Buf;
 use bytes::Bytes;
 use futures_util::StreamExt;
 use http_body::Frame;
-use http_body_util::{combinators::BoxBody, BodyExt};
+use http_body_util::{combinators::UnsyncBoxBody, BodyExt};
 
 #[derive(Debug)]
-pub struct Body(BoxBody<Bytes, crate::Error>);
+pub struct Body(UnsyncBoxBody<Bytes, crate::Error>);
 
 impl Default for Body {
     fn default() -> Self {
@@ -41,24 +41,24 @@ impl Body {
         Body(
             http_body_util::Empty::<Bytes>::new()
                 .map_err(crate::Error::new)
-                .boxed(),
+                .boxed_unsync(),
         )
     }
 
     pub(crate) fn wrap<B>(body: B) -> Self
     where
-        B: http_body::Body + Send + Sync + 'static,
+        B: http_body::Body + Send + 'static,
         B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
         let body = body
             .map_frame(|f| f.map_data(|mut buf| buf.copy_to_bytes(buf.remaining())))
             .map_err(crate::Error::new);
-        Body(http_body_util::BodyExt::boxed(body))
+        Body(http_body_util::BodyExt::boxed_unsync(body))
     }
 
     pub(crate) fn wrap_stream<S, B, E>(stream: S) -> Self
     where
-        S: futures_util::Stream<Item = Result<B, E>> + Send + Sync + 'static,
+        S: futures_util::Stream<Item = Result<B, E>> + Send + 'static,
         B: Into<Bytes>,
         E: Into<Box<dyn std::error::Error + Send + Sync>> + Send + 'static,
     {
@@ -66,7 +66,7 @@ impl Body {
             item.map(|buf| Frame::data(buf.into()))
                 .map_err(crate::Error::new)
         }));
-        Body(http_body_util::BodyExt::boxed(body))
+        Body(http_body_util::BodyExt::boxed_unsync(body))
     }
 }
 
@@ -75,7 +75,7 @@ impl From<Bytes> for Body {
         Body(
             http_body_util::Full::new(b)
                 .map_err(crate::Error::new)
-                .boxed(),
+                .boxed_unsync(),
         )
     }
 }

--- a/src/filter/service.rs
+++ b/src/filter/service.rs
@@ -75,7 +75,7 @@ where
     F: Filter,
     <F::Future as TryFuture>::Ok: Reply,
     <F::Future as TryFuture>::Error: IsReject,
-    B: http_body::Body + Send + Sync + 'static,
+    B: http_body::Body + Send + 'static,
     B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     type Response = Response;

--- a/src/filters/sse.rs
+++ b/src/filters/sse.rs
@@ -229,7 +229,7 @@ impl fmt::Display for Event {
 /// ```
 pub fn last_event_id<T>() -> impl Filter<Extract = One<Option<T>>, Error = Rejection> + Copy
 where
-    T: FromStr + Send + Sync + 'static,
+    T: FromStr + Send + 'static,
 {
     header::optional("last-event-id")
 }
@@ -313,7 +313,7 @@ where
 /// ```
 pub fn reply<S>(event_stream: S) -> impl Reply
 where
-    S: TryStream<Ok = Event> + Send + Sync + 'static,
+    S: TryStream<Ok = Event> + Send + 'static,
     S::Error: StdError + Send + Sync + 'static,
 {
     SseReply { event_stream }
@@ -326,7 +326,7 @@ struct SseReply<S> {
 
 impl<S> Reply for SseReply<S>
 where
-    S: TryStream<Ok = Event> + Send + Sync + 'static,
+    S: TryStream<Ok = Event> + Send + 'static,
     S::Error: StdError + Send + Sync + 'static,
 {
     #[inline]

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -143,7 +143,7 @@ impl Reply for Json {
 /// ```
 pub fn stream<S, B, E>(stream: S) -> impl Reply
 where
-    S: futures_util::Stream<Item = Result<B, E>> + Send + Sync + 'static,
+    S: futures_util::Stream<Item = Result<B, E>> + Send + 'static,
     B: Into<bytes::Bytes>,
     E: Into<Box<dyn std::error::Error + Send + Sync>> + Send + 'static,
 {


### PR DESCRIPTION
Fixes #1153

Remove `Sync` from `Body`'s trait bounds.
Also removes `Sync` from the various `Stream` objects as this also appears safe.