### PR TITLE
fix: Don't treat OPTIONS as CORS preflight if request-method not set

### DIFF
--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -371,9 +371,9 @@ impl Configured {
                     }
                 } else {
                     tracing::trace!(
-                        "preflight request missing access-control-request-method header"
+                        "missing access-control-request-method header, not a valid preflight request"
                     );
-                    return Err(Forbidden::MethodNotAllowed);
+                    return Ok(Validated::NotCors);
                 }
 
                 if let Some(req_headers) = headers.get(header::ACCESS_CONTROL_REQUEST_HEADERS) {

--- a/tests/cors.rs
+++ b/tests/cors.rs
@@ -182,3 +182,17 @@ async fn with_log() {
 
     assert_eq!(res.status(), 200);
 }
+
+#[tokio::test]
+async fn notcors() {
+    let cors = warp::cors();
+    let route = warp::any().map(warp::reply).with(cors);
+
+    let res = warp::test::request()
+        .method("OPTIONS")
+        .header("origin", "http://example.com")
+        .reply(&route)
+        .await;
+
+    assert_eq!(res.status(), 200);
+}


### PR DESCRIPTION
As per the spec (https://fetch.spec.whatwg.org/#http-requests) and the MDN docs (https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request), a CORS preflight request should include at least the Origin as well as Access-Control-Request-Method headers in the OPTIONS request.

So we should not consider an OPTIONS request as a CORS preflight request if it does not include the Access-Control-Request-Method header and instead return Validated:::NotCors, so it will pass through