### PR TITLE
Remove unnecessary clone when creating a new `TlsStream`

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -390,7 +390,7 @@ impl Accept for TlsAcceptor {
     ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
         let pin = self.get_mut();
         match ready!(Pin::new(&mut pin.incoming).poll_accept(cx)) {
-            Some(Ok(sock)) => Poll::Ready(Some(Ok(TlsStream::new(sock, pin.config.clone())))),
+            Some(Ok(sock)) => Poll::Ready(Some(Ok(TlsStream::new(sock, pin.config)))),
             Some(Err(e)) => Poll::Ready(Some(Err(e))),
             None => Poll::Ready(None),
         }


### PR DESCRIPTION
Since the `pin` variable will not be used later, it can be moved rather than cloned.

CC @nunoplopes