### PR TITLE
Normalize absent path_and_query to root

### DIFF
--- a/src/filters/path.rs
+++ b/src/filters/path.rs
@@ -466,7 +466,7 @@ fn path_and_query(route: &Route) -> PathAndQuery {
         .uri()
         .path_and_query()
         .cloned()
-        .unwrap_or_else(|| PathAndQuery::from_static(""))
+        .unwrap_or_else(|| PathAndQuery::from_static("/"))
 }
 
 /// Convenient way to chain multiple path filters together.

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -2,7 +2,11 @@
 #[macro_use]
 extern crate warp;
 
+use bytes::Bytes;
 use futures_util::future;
+use http_body_util::BodyExt;
+use http_body_util::Empty;
+use tower_service::Service;
 use warp::Filter;
 
 #[tokio::test]
@@ -328,6 +332,27 @@ async fn full_path() {
         .await
         .unwrap();
     assert_eq!(ex.as_str(), "/");
+}
+
+#[tokio::test]
+async fn full_path_connect_authority_form() {
+    let route = warp::path::full().map(|path: warp::path::FullPath| path.as_str().to_owned());
+    let mut service = warp::service(route);
+
+    let request = http::Request::builder()
+        .method("CONNECT")
+        .uri("example.com:443")
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+
+    assert_eq!(request.uri().path(), "");
+    assert_eq!(request.uri().path_and_query(), None);
+
+    let response = service.call(request).await.unwrap();
+    assert_eq!(response.status(), http::StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+
+    assert_eq!(&body[..], b"/");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes `warp::path::full()` panicking for authority-form `CONNECT` requests when using newer `http` (>=1.4.1) versions that reject `PathAndQuery::from_static("")`.

  When a request URI has no `path_and_query`, normalize it explicitly to `/` instead of constructing a `PathAndQuery` from the empty string.

  Closes #1166.

  Tested:
  - `cargo fmt -- --check`
  - `cargo test full_path --features test`