### PR TITLE
cors: a non-preflight OPTIONS request can still be CORS if it holds an Origin

### DIFF
--- a/src/filters/cors.rs
+++ b/src/filters/cors.rs
@@ -349,6 +349,7 @@ enum Validated {
     Preflight(HeaderValue),
     Simple(HeaderValue),
     NotCors,
+    NotPreflight(HeaderValue),
 }
 
 impl Configured {
@@ -359,7 +360,7 @@ impl Configured {
     ) -> Result<Validated, Forbidden> {
         match (headers.get(header::ORIGIN), method) {
             (Some(origin), &http::Method::OPTIONS) => {
-                // OPTIONS requests are preflight CORS requests...
+                // OPTIONS requests may be preflight CORS requests...
 
                 if !self.is_origin_allowed(origin) {
                     return Err(Forbidden::OriginNotAllowed);
@@ -373,7 +374,7 @@ impl Configured {
                     tracing::trace!(
                         "missing access-control-request-method header, not a valid preflight request"
                     );
-                    return Ok(Validated::NotCors);
+                    return Ok(Validated::NotPreflight(origin.clone()));
                 }
 
                 if let Some(req_headers) = headers.get(header::ACCESS_CONTROL_REQUEST_HEADERS) {
@@ -507,6 +508,10 @@ mod internal {
                 Ok(Validated::NotCors) => future::Either::Right(WrappedFuture {
                     inner: self.inner.filter(Internal),
                     wrapped: None,
+                }),
+                Ok(Validated::NotPreflight(origin)) => future::Either::Right(WrappedFuture {
+                    inner: self.inner.filter(Internal),
+                    wrapped: Some((self.config.clone(), origin)),
                 }),
                 Err(err) => {
                     let rejection = crate::reject::known(CorsForbidden { kind: err });

--- a/tests/cors.rs
+++ b/tests/cors.rs
@@ -184,7 +184,7 @@ async fn with_log() {
 }
 
 #[tokio::test]
-async fn notcors() {
+async fn notpreflight() {
     let cors = warp::cors();
     let route = warp::any().map(warp::reply).with(cors);
 
@@ -195,4 +195,8 @@ async fn notcors() {
         .await;
 
     assert_eq!(res.status(), 200);
+    assert_eq!(
+        res.headers()["access-control-allow-origin"],
+        "http://example.com"
+    );
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/seanmonstar/warp , my actual use case had chrome complaining about the lack of an `Access-Control-Allow-Origin` header in the response of an OPTIONS request sent as part of a [WHEP] exchange: while it is not a preflight request due to the lack of an `Access-Control-Request-Method` it should still be treated as CORS. Fix by defining a new `NotPreflight` variant holding the origin.

[WHEP]: https://datatracker.ietf.org/doc/draft-ietf-wish-whep/